### PR TITLE
Implement universal logger for project-wide use (zap)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/asenalabs/asena
 
 go 1.24.2
+
+require (
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -1,0 +1,40 @@
+package logger
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var logg *zap.Logger
+
+func IntiFallbackZapLogger() {
+	var zapCfg zap.Config
+	var encoder zapcore.Encoder
+
+	zapCfg = zap.NewDevelopmentConfig()
+	encoder = zapcore.NewConsoleEncoder(zapCfg.EncoderConfig)
+
+	var writer zapcore.WriteSyncer
+	writer = zapcore.AddSync(os.Stdout)
+
+	core := zapcore.NewCore(encoder, writer, zapcore.DebugLevel)
+
+	logg = zap.New(core, zap.AddCaller())
+}
+
+func Get() *zap.Logger {
+	if logg == nil {
+		panic("Logger not initialized")
+	}
+	return logg
+}
+
+func Sync() {
+	if logg != nil {
+		if err := logg.Sync(); err != nil {
+			panic("Failed to sync logger: " + err.Error())
+		}
+	}
+}

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestLoggingOutput(t *testing.T) {
+	core, observedLogs := observer.New(zapcore.DebugLevel)
+	logg = zap.New(core)
+
+	Get().Info("test message")
+
+	logs := observedLogs.All()
+	if len(logs) != 1 {
+		t.Errorf("got %d logs, expected 1", len(logs))
+	}
+	if logs[0].Message != "test message" {
+		t.Errorf("got unexpected message: %s", logs[0].Message)
+	}
+}
+
+func TestGetLoggerPanics(t *testing.T) {
+	logg = nil
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic when logger is not initialized")
+		}
+	}()
+
+	_ = Get()
+}
+
+func TestGetLoggerReturnsLogger(t *testing.T) {
+	IntiFallbackZapLogger()
+	logg := Get()
+	if logg == nil {
+		t.Fatal("expected non-nil logg")
+	}
+}
+
+func TestSyncDoesNotPanic(t *testing.T) {
+	IntiFallbackZapLogger()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Sync panicked: %v", r)
+		}
+	}()
+	Sync()
+}


### PR DESCRIPTION
This PR adds a reusable logger using zap.  
It will be used in the project.
Closes #2 