### PR TITLE
feat(logger): integrate InitProductionZapLogger into startasena

### DIFF
--- a/access.log
+++ b/access.log
@@ -1,0 +1,4 @@
+2025-09-23T21:55:00.058+0500	INFO	cmd/startasena.go:32	Starting asena	{"version": "0.0.3", "env": "development"}
+2025-09-23T21:55:00.058+0500	INFO	cmd/startasena.go:33	Asena configuration	{"enable https": false}
+{"level":"INFO","timestamp":"2025-09-23T22:01:22.130+0500","caller":"cmd/startasena.go:32","msg":"Starting asena","version":"0.0.4","env":"production"}
+{"level":"INFO","timestamp":"2025-09-23T22:01:22.130+0500","caller":"cmd/startasena.go:33","msg":"Asena configuration","enable https":false}

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	version             = "0.0.3"
-	env                 = "development" //	development | production
+	version             = "0.0.4"
+	env                 = "production" //	development | production
 	asenaConfigFilePath = "asena.yaml"
 )
 
@@ -23,6 +23,11 @@ func StartAsena() {
 		logg.Fatal("Failed to initialize Asena configurations", zap.Error(err))
 	}
 	asenaCfg := asenaConfigService.Get()
+
+	//	Switch logger according to config
+	logger.InitProductionZapLogger(env, asenaCfg.Log)
+	logg = logger.Get()
+	defer logger.Sync()
 
 	logg.Info("Starting asena", zap.String("version", version), zap.String("env", env))
 	logg.Info("Asena configuration", zap.Bool("enable https", *asenaCfg.Asena.EnableHTTPS))


### PR DESCRIPTION
Closes #12

### Changes
- Integrated `InitProductionZapLogger` for production-ready logging
- Ensured `InitFallbackZapLogger` remains functional as a fallback
- Ensured `InitProductionZapLogger` writes logs as JSON format into `access.log`