### PR TITLE
fix (logger): ignore zap.Logger.Sync() error to prevent runtime panic (#14)

### DIFF
--- a/access.log
+++ b/access.log
@@ -2,3 +2,5 @@
 2025-09-23T21:55:00.058+0500	INFO	cmd/startasena.go:33	Asena configuration	{"enable https": false}
 {"level":"INFO","timestamp":"2025-09-23T22:01:22.130+0500","caller":"cmd/startasena.go:32","msg":"Starting asena","version":"0.0.4","env":"production"}
 {"level":"INFO","timestamp":"2025-09-23T22:01:22.130+0500","caller":"cmd/startasena.go:33","msg":"Asena configuration","enable https":false}
+2025-09-23T22:24:07.078+0500	INFO	cmd/startasena.go:32	Starting asena	{"version": "0.0.5", "env": "development"}
+2025-09-23T22:24:07.078+0500	INFO	cmd/startasena.go:33	Asena configuration	{"enable https": false}

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	version             = "0.0.4"
-	env                 = "production" //	development | production
+	version             = "0.0.5"
+	env                 = "development" //	development | production
 	asenaConfigFilePath = "asena.yaml"
 )
 

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -85,8 +85,6 @@ func Get() *zap.Logger {
 
 func Sync() {
 	if logg != nil {
-		if err := logg.Sync(); err != nil {
-			panic("Failed to sync logger: " + err.Error())
-		}
+		_ = logg.Sync()
 	}
 }


### PR DESCRIPTION
This PR updates the logger.Sync() function to safely ignore the error
returned by zap.Logger.Sync(). According to the official uber-go/zap
documentation, Sync flushes any buffered log entries, but on Linux
os.Stdout and os.Stderr often do not support fsync, causing an
“invalid argument” error.

By ignoring this error we prevent unnecessary runtime panics in
production and containerized environments.

Reference:
https://pkg.go.dev/go.uber.org/zap#Logger.Sync

Closes #14