### PR TITLE
feat (cmd): integrate dynamic config loader with hot-reload (#18)

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -1,18 +1,27 @@
 package cmd
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/asenalabs/asena/internal/config"
 	"github.com/asenalabs/asena/pkg/logger"
 	"go.uber.org/zap"
 )
 
 var (
-	version             = "0.0.6"
-	env                 = "development" //	development | production
-	asenaConfigFilePath = "asena.yaml"
+	version               = "0.0.7"
+	env                   = "development" //	development | production
+	asenaConfigFilePath   = "asena.yaml"
+	dynamicConfigFilePath = "dynamic.yaml"
 )
 
 func StartAsena() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	//	Initialize basic logger
 	logger.IntiFallbackZapLogger()
 	logg := logger.Get()
@@ -28,6 +37,18 @@ func StartAsena() {
 	logger.InitProductionZapLogger(env, asenaCfg.Log)
 	logg = logger.Get()
 	defer logger.Sync()
+
+	//	Load dynamic configurations
+	dynamicConfigService, err := config.NewDynamicConfigService(ctx, dynamicConfigFilePath, logg)
+	if err != nil {
+		logg.Fatal("Failed to initialize dynamic configurations", zap.Error(err))
+	}
+
+	go func() {
+		for _ = range dynamicConfigService.Updates() {
+
+		}
+	}()
 
 	logg.Info("Starting asena", zap.String("version", version), zap.String("env", env))
 	logg.Info("Asena configuration", zap.Bool("enable https", *asenaCfg.Asena.EnableHTTPS))


### PR DESCRIPTION
### Summary
This PR wires the `dynamic.yaml` loader into the `cmd/startasena.go` entrypoint.  
Asena now supports dynamic routing at runtime without restarting the server.

### Changes
- Load `asena.yaml` as static base config
- Watch `dynamic.yaml` for changes using fsnotify
- Apply valid updates to the running server
- Keep serving last valid config on error
- Log reload events via zap.Logger
- Bumped version to 0.0.7

Closes #18
