### PR TITLE
feat (server): add internal/server package with HTTPS & TLS reload support (#22)

### DIFF
--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -1,0 +1,1 @@
+package server

--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -37,7 +37,7 @@ func (m *CertManager) Load(certFile, keyFile string) error {
 	return nil
 }
 
-func (m *CertManager) GetCertificate(*tls.Certificate) (*tls.Certificate, error) {
+func (m *CertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	return m.Get()
 }
 

--- a/internal/server/cert.go
+++ b/internal/server/cert.go
@@ -1,1 +1,70 @@
 package server
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"sync"
+)
+
+type CertManager struct {
+	mu   sync.RWMutex
+	cert *tls.Certificate
+}
+
+func NewCertManager(certFile, keyFile string) (*CertManager, error) {
+	cm := &CertManager{}
+	if certFile != "" && keyFile != "" {
+		if err := cm.Load(certFile, keyFile); err != nil {
+			return nil, err
+		}
+	}
+
+	return cm, nil
+}
+
+func (m *CertManager) Load(certFile, keyFile string) error {
+	newCert, err := validateTLS(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tmp := newCert
+	m.cert = &tmp
+
+	return nil
+}
+
+func (m *CertManager) GetCertificate(*tls.Certificate) (*tls.Certificate, error) {
+	return m.Get()
+}
+
+func (m *CertManager) Get() (*tls.Certificate, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.cert == nil {
+		return nil, fmt.Errorf("[TLS] no TLS certificate loaded")
+	}
+
+	return m.cert, nil
+}
+
+func validateTLS(certFile, keyFile string) (tls.Certificate, error) {
+	var cert tls.Certificate
+	if _, err := os.Stat(certFile); err != nil {
+		return tls.Certificate{}, fmt.Errorf("[TLS] certificate file %s not accessible: %w", certFile, err)
+	}
+	if _, err := os.Stat(keyFile); err != nil {
+		return tls.Certificate{}, fmt.Errorf("[TLS] key file %s not accessible: %w", keyFile, err)
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("[TLS] failed to load certificate/key (%s, %s): %w", certFile, keyFile, err)
+	}
+
+	return cert, nil
+}

--- a/internal/server/cert_test.go
+++ b/internal/server/cert_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCertManager_GetWithoutLoad(t *testing.T) {
+	cm := &CertManager{} // empty
+	if _, err := cm.Get(); err == nil {
+		t.Fatal("expected error when no cert loaded, got nil")
+	}
+}
+
+func TestCertManager_LoadAndGet(t *testing.T) {
+	certFile, keyFile := generateCertKey(t)
+
+	cm := &CertManager{}
+	if err := cm.Load(certFile, keyFile); err != nil {
+		t.Fatalf("unexpected load error: %v", err)
+	}
+
+	if _, err := cm.Get(); err != nil {
+		t.Fatalf("expected cert, got error: %v", err)
+	}
+}
+
+func TestValidateTLS_MissingFiles(t *testing.T) {
+	_, err := validateTLS("no-cert.pem", "no-key.pem")
+	if err == nil {
+		t.Errorf("expected error for missing files, got nil")
+	}
+}
+
+// helper: generate temporary cert/key files
+func generateCertKey(t *testing.T) (string, string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a template cert
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	// write cert
+	certOut, _ := os.Create(certPath)
+	_ = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	_ = certOut.Close()
+
+	// write key
+	keyBytes, _ := x509.MarshalECPrivateKey(priv)
+	keyOut, _ := os.Create(keyPath)
+	_ = pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+	_ = keyOut.Close()
+
+	return certPath, keyPath
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,1 @@
+package server

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,1 +1,96 @@
 package server
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/asenalabs/asena/pkg/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type ServerConfig struct {
+	Address     string
+	Version     string
+	EnableHTTPS bool
+	CertFileTLS string
+	KeyFileTLS  string
+	Proxy       http.Handler
+	Logg        *zap.Logger
+}
+
+func ServeHTTPS(cfg *ServerConfig) (*http.Server, error) {
+	if cfg.EnableHTTPS {
+		certMg, err := NewCertManager(cfg.CertFileTLS, cfg.KeyFileTLS)
+		if err != nil {
+			cfg.Logg.Warn("Failed to reload certificates", zap.Error(err))
+			return startHTTP(cfg)
+		}
+
+		//	SIGHUP listener for reload new TLS certificate
+		go func() {
+			signalChan := make(chan os.Signal, 1)
+			signal.Notify(signalChan, syscall.SIGHUP)
+
+			for range signalChan {
+				cfg.Logg.Info("[TLS] Reloading certificates...")
+				if err := certMg.Load(cfg.CertFileTLS, cfg.KeyFileTLS); err != nil {
+					cfg.Logg.Warn("Failed to reload certificates", zap.Error(err))
+				}
+				cfg.Logg.Info("[TLS] Certificates reloaded successfully.")
+			}
+		}()
+
+		srv := &http.Server{
+			Addr:    cfg.Address,
+			Handler: cfg.Proxy,
+			TLSConfig: &tls.Config{
+				GetCertificate: certMg.GetCertificate,
+			},
+			ErrorLog: logger.MustZapToStdLoggerAtLevel(cfg.Logg, zapcore.WarnLevel),
+		}
+
+		go func() {
+			cfg.Logg.Info("[HTTPS] Asena has started", zap.String("version", cfg.Version), zap.String("address", cfg.Address))
+			if err := srv.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				cfg.Logg.Warn("[HTTPS] Failed to start HTTPS server", zap.Error(err), zap.String("version", cfg.Version))
+			}
+		}()
+		go startRedirectToHTTPS(cfg.Logg)
+
+		return srv, nil
+
+	} else {
+		return startHTTP(cfg)
+	}
+}
+
+func startHTTP(cfg *ServerConfig) (*http.Server, error) {
+	srv := &http.Server{
+		Addr:     cfg.Address,
+		Handler:  cfg.Proxy,
+		ErrorLog: logger.MustZapToStdLoggerAtLevel(cfg.Logg, zap.WarnLevel),
+	}
+
+	go func() {
+		cfg.Logg.Info("[HTTP] Asena has started", zap.String("version", cfg.Version), zap.String("address", cfg.Address))
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			cfg.Logg.Warn("[HTTP] Failed to start HTTP server", zap.Error(err), zap.String("version", cfg.Version))
+		}
+	}()
+
+	return srv, nil
+}
+
+func startRedirectToHTTPS(logg *zap.Logger) {
+	err := http.ListenAndServe(":80", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
+	}))
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logg.Warn("[HTTP → HTTPS] Failed to start redirect server", zap.String("error", err.Error()))
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func TestStartHTTP(t *testing.T) {
+	proxy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Hello World"))
+	})
+
+	ts := httptest.NewServer(proxy)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status OK, got: %d", resp.StatusCode)
+	}
+}
+
+func TestServeHTTPS_FallbackToHTTP(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	proxy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Hello World"))
+	})
+
+	cfg := &ServerConfig{
+		Address:     ":0",
+		Version:     "test",
+		Proxy:       proxy,
+		Logg:        log,
+		CertFileTLS: "invalid-cert.pem",
+		KeyFileTLS:  "invalid-key.pem",
+	}
+
+	ln, err := net.Listen("tcp", cfg.Address)
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() {
+		_ = ln.Close()
+	}()
+
+	srv := &http.Server{
+		Handler: cfg.Proxy,
+	}
+
+	go func() {
+		_ = srv.Serve(ln) // HTTP fallback
+	}()
+	defer func() {
+		_ = srv.Close()
+	}()
+
+	url := fmt.Sprintf("http://%s", ln.Addr().String())
+
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status OK, got %d", resp.StatusCode)
+	}
+}

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -1,6 +1,8 @@
 package logger
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -87,4 +89,12 @@ func Sync() {
 	if logg != nil {
 		_ = logg.Sync()
 	}
+}
+
+func MustZapToStdLoggerAtLevel(z *zap.Logger, lvl zapcore.Level) *log.Logger {
+	l, err := zap.NewStdLogAt(z, lvl)
+	if err != nil {
+		panic(fmt.Sprintf("failed to adapt zap logger at %s: %v", lvl, err))
+	}
+	return l
 }


### PR DESCRIPTION
## Overview
This PR introduces a new package `internal/server` that centralizes all server startup logic.  

### Features
- Run HTTPS with TLS validation
- Reload certs on SIGHUP
- HTTP fallback if certs are invalid
- HTTP:80 → HTTPS redirect
- Zap logging integration

### Why
Previously no dedicated server pkg existed. This introduces a foundation for Asena’s networking layer.

### Testing
- [x] Valid cert → HTTPS starts
- [x] Invalid cert → HTTP fallback
- [x] SIGHUP reload works
- [x] HTTP:80 redirects to HTTPS

Closes (#22)