### PR TITLE
Feature/reverse proxy manager #26

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	version               = "0.0.9"
+	version               = "0.1.0"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "asena.yaml"
 	dynamicConfigFilePath = "dynamic.yaml"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/asenalabs/asena
 go 1.24.2
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -117,8 +117,8 @@ func normalizeProxyTransportCfg(cfg *ProxyTransportCfg) {
 // ============================== Dynamic ==============================
 
 var (
-	roundRobin = "round-robin"
-	//weightedRoundRobin = "weighted-round-robin"
+	RoundRobin = "round-robin"
+	//WeightedRoundRobin = "weighted-round-robin"
 	flashInterval       = 500 * time.Millisecond
 	passHostHeaderFalse = false
 )
@@ -170,8 +170,8 @@ func validateServiceAlgorithm(alg *string) error {
 	}
 
 	algorithms := map[string]uint{
-		roundRobin: 1,
-		// weightedRoundRobin: 2,
+		RoundRobin: 1,
+		// WeightedRoundRobin: 2,
 	}
 
 	if _, found := algorithms[*alg]; !found {
@@ -187,7 +187,7 @@ func normalizeServicesCfg(cfg *ServiceCfg) {
 	}
 
 	if cfg.LoadBalancer.Algorithm == nil {
-		cfg.LoadBalancer.Algorithm = &roundRobin
+		cfg.LoadBalancer.Algorithm = &RoundRobin
 	}
 	if cfg.LoadBalancer.FlashInterval == nil {
 		cfg.LoadBalancer.FlashInterval = &flashInterval

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -78,7 +78,7 @@ func TestValidateHTTPCfg(t *testing.T) {
 
 func TestValidateServiceCfg(t *testing.T) {
 	url := "http://localhost:9000"
-	alg := roundRobin
+	alg := RoundRobin
 
 	tests := []struct {
 		name    string
@@ -115,7 +115,7 @@ func TestValidateServiceCfg(t *testing.T) {
 
 func TestValidateServiceAlgorithm(t *testing.T) {
 	badAlg := "no-algorithm"
-	goodAlg := roundRobin
+	goodAlg := RoundRobin
 
 	tests := []struct {
 		name    string
@@ -150,7 +150,7 @@ func TestNormalizeServicesCfg(t *testing.T) {
 	if cfg.LoadBalancer == nil {
 		t.Fatal("expected LoadBalancer to be initialized, got nil")
 	}
-	if cfg.LoadBalancer.Algorithm == nil || *cfg.LoadBalancer.Algorithm != roundRobin {
+	if cfg.LoadBalancer.Algorithm == nil || *cfg.LoadBalancer.Algorithm != RoundRobin {
 		t.Errorf("expected Algorithm=roundRobin, got %v", cfg.LoadBalancer.Algorithm)
 	}
 	if cfg.LoadBalancer.FlashInterval == nil || *cfg.LoadBalancer.FlashInterval != flashInterval {

--- a/internal/proxy/balancer/balancer.go
+++ b/internal/proxy/balancer/balancer.go
@@ -1,0 +1,16 @@
+package balancer
+
+import "github.com/asenalabs/asena/internal/config"
+
+type Balancer interface {
+	Next() *config.ServerCfg
+}
+
+func New(algorithm string, servers []*config.ServerCfg) Balancer {
+	switch algorithm {
+	case config.RoundRobin:
+		return NewRoundRobin(servers)
+	default:
+		return NewRoundRobin(servers) // default fallback
+	}
+}

--- a/internal/proxy/balancer/roundrobin.go
+++ b/internal/proxy/balancer/roundrobin.go
@@ -1,0 +1,33 @@
+package balancer
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/asenalabs/asena/internal/config"
+)
+
+type RoundRobin struct {
+	mu      sync.RWMutex
+	servers []*config.ServerCfg
+	counter uint64
+}
+
+func NewRoundRobin(servers []*config.ServerCfg) *RoundRobin {
+	return &RoundRobin{
+		servers: servers,
+	}
+}
+
+func (rr *RoundRobin) Next() *config.ServerCfg {
+	rr.mu.RLock()
+	defer rr.mu.RUnlock()
+
+	l := len(rr.servers)
+	if l == 0 {
+		return nil
+	}
+
+	pos := atomic.AddUint64(&rr.counter, 1)
+	return rr.servers[pos%uint64(l)]
+}

--- a/internal/proxy/balancer/roundrobin_test.go
+++ b/internal/proxy/balancer/roundrobin_test.go
@@ -1,0 +1,79 @@
+package balancer
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/asenalabs/asena/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestRoundRobin_Empty(t *testing.T) {
+	rr := NewRoundRobin(nil)
+	require.Nil(t, rr.Next())
+}
+
+func TestRoundRobin_Sequence(t *testing.T) {
+	servers := []*config.ServerCfg{
+		{URL: strPtr("s1")}, {URL: strPtr("s2")}, {URL: strPtr("s3")},
+	}
+	rr := NewRoundRobin(servers)
+
+	want := []string{"s2", "s3", "s1", "s2", "s3", "s1"}
+	for i, w := range want {
+		got := rr.Next()
+		require.NotNil(t, got)
+		require.Equal(t, w, *got.URL, "step %d", i)
+	}
+}
+
+func TestRoundRobin_CounterWrap(t *testing.T) {
+	servers := []*config.ServerCfg{{URL: strPtr("only")}}
+	rr := NewRoundRobin(servers)
+
+	atomic.AddUint64(&rr.counter, ^uint64(0)-1)
+	require.Equal(t, "only", *rr.Next().URL)
+}
+
+func TestRoundRobin_Concurrent(t *testing.T) {
+	servers := []*config.ServerCfg{
+		{URL: strPtr("s1")}, {URL: strPtr("s2")}, {URL: strPtr("s3")},
+	}
+
+	rr := NewRoundRobin(servers)
+
+	const workers = 50
+	const iterations = 200
+
+	results := make(chan string, workers*iterations)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				if srv := rr.Next(); srv != nil {
+					results <- *srv.URL
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	seen := map[string]bool{}
+	for url := range results {
+		seen[url] = true
+	}
+	for _, srv := range servers {
+		require.True(t, seen[*srv.URL], "server %s should be selected", *srv.URL)
+	}
+}

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sync"
+	"sync/atomic"
+
+	"github.com/asenalabs/asena/internal/config"
+	"github.com/asenalabs/asena/internal/proxy/balancer"
+	"github.com/asenalabs/asena/pkg/logger"
+	"go.uber.org/zap"
+)
+
+type Manager struct {
+	ProxyHolder  atomic.Value
+	RouterHolder atomic.Value
+	mu           sync.RWMutex
+	logg         *zap.Logger
+}
+
+func NewProxyManger(logg *zap.Logger) *Manager {
+	pm := &Manager{
+		logg: logg,
+	}
+	pm.ProxyHolder.Store(make(map[string]*httputil.ReverseProxy))
+	pm.RouterHolder.Store(make(map[string]*config.RoutersCfg))
+
+	return pm
+}
+
+func (pm *Manager) BuildReverseProxy(cfg *config.HTTPCfg, t *config.ProxyTransportCfg) {
+	if cfg == nil || t == nil {
+		pm.logg.Error("Proxy transport config is nil")
+		return
+	}
+
+	newProxies := make(map[string]*httputil.ReverseProxy)
+	for name, group := range cfg.Services {
+		rp, err := pm.newReverseProxy(t, group.LoadBalancer)
+		if err != nil {
+			pm.logg.Error("Failed to build reverse proxy", zap.String("service", name), zap.Error(err))
+		}
+
+		newProxies[name] = rp
+		pm.logg.Info("Reverse proxy built", zap.String("service", name), zap.String("algorithm", *group.LoadBalancer.Algorithm), zap.Int("services_count", len(group.LoadBalancer.Servers)))
+	}
+
+	newRouters := make(map[string]*config.RoutersCfg)
+	for name, router := range cfg.Routers {
+		newRouters[name] = router
+		pm.logg.Info("Router registered", zap.String("router", name), zap.String("rule", *router.Rule))
+	}
+
+	pm.mu.Lock()
+	pm.ProxyHolder.Store(newProxies)
+	pm.RouterHolder.Store(newRouters)
+	pm.mu.Unlock()
+}
+
+func (pm *Manager) newReverseProxy(t *config.ProxyTransportCfg, l *config.LoadBalancerCfg) (*httputil.ReverseProxy, error) {
+	bl := balancer.New(*l.Algorithm, l.Servers)
+
+	rp := &httputil.ReverseProxy{
+		Transport:     newProxyTransport(t),
+		FlushInterval: *l.FlashInterval,
+		ErrorLog:      logger.MustZapToStdLoggerAtLevel(pm.logg, zap.WarnLevel),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, e error) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.WriteHeader(http.StatusBadGateway) // 502 Bad Gateway
+
+			resp := map[string]interface{}{
+				"error":   "Service not available",
+				"code":    http.StatusBadGateway,
+				"message": "Please try again later.",
+			}
+
+			_ = json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	rp.Director = func(req *http.Request) {
+		server := bl.Next()
+		if server == nil || server.URL == nil {
+			pm.logg.Warn("No server available for proxy", zap.String("url", req.URL.String()))
+		}
+
+		target, err := url.Parse(*server.URL)
+		if err != nil {
+			pm.logg.Warn("Invalid server URL", zap.String("url", *server.URL), zap.Error(err))
+			return
+		}
+
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+
+		if l.PassHostHeader != nil && *l.PassHostHeader {
+			req.Host = target.Host
+		}
+	}
+
+	rp.ModifyResponse = func(resp *http.Response) error {
+		resp.Header.Set("X-Content-Type-Options", "nosniff")
+		resp.Header.Set("X-Frame-Options", "DENY")
+
+		if resp.StatusCode >= http.StatusBadRequest {
+			pm.logg.Warn("Proxy response error", zap.Int("status_code", resp.StatusCode), zap.String("service", resp.Request.URL.Host), zap.String("url", resp.Request.URL.String()))
+		}
+
+		return nil
+	}
+
+	return rp, nil
+}
+
+func newProxyTransport(t *config.ProxyTransportCfg) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   *t.DailTimeout,
+			KeepAlive: *t.DailKeepalive,
+		}).DialContext,
+		ForceAttemptHTTP2:     *t.ForceHTTP2,
+		MaxIdleConns:          *t.MaxIdleConn,
+		MaxConnsPerHost:       *t.MaxIdleConnPerHost,
+		IdleConnTimeout:       *t.IdleConnTimeout,
+		TLSHandshakeTimeout:   *t.TLSHandshakeTimeout,
+		ExpectContinueTimeout: *t.ExpectContinueTimeout,
+		TLSClientConfig: &tls.Config{
+			MinVersion: *t.TLSMinVersion,
+		},
+	}
+}
+
+func (pm *Manager) GetProxy(serviceName string) (*httputil.ReverseProxy, bool) {
+	value := pm.ProxyHolder.Load()
+	proxies, ok := value.(map[string]*httputil.ReverseProxy)
+	if !ok || proxies == nil {
+		return nil, false
+	}
+
+	rp, exists := proxies[serviceName]
+	return rp, exists
+}

--- a/internal/proxy/manager_test.go
+++ b/internal/proxy/manager_test.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/asenalabs/asena/internal/config"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestNewProxyManager_Init(t *testing.T) {
+	logg := zaptest.NewLogger(t)
+	pm := NewProxyManger(logg)
+
+	if pm == nil {
+		t.Fatal("expected manager to be non-nil")
+	}
+
+	if _, ok := pm.ProxyHolder.Load().(map[string]*httputil.ReverseProxy); !ok {
+		t.Error("expected ProxyHolder to contain map[string]*ReverseProxy")
+	}
+
+	if _, ok := pm.RouterHolder.Load().(map[string]*config.RoutersCfg); !ok {
+		t.Error("expected RouterHolder to contain map[string]*RoutersCfg")
+	}
+}
+
+func TestBuildReverseProxy_ValidConfig(t *testing.T) {
+	logg := zaptest.NewLogger(t)
+
+	pm := NewProxyManger(logg)
+
+	algo := "round-robin"
+	rule := "Host(`/api`)"
+	flash := 50 * time.Millisecond
+	passHost := true
+	urlStr := "http://127.0.0.1:8080"
+
+	cfg := &config.HTTPCfg{
+		Services: map[string]*config.ServiceCfg{
+			"api-service": {
+				LoadBalancer: &config.LoadBalancerCfg{
+					Algorithm:      &algo,
+					Servers:        []*config.ServerCfg{{URL: &urlStr}},
+					FlashInterval:  &flash,
+					PassHostHeader: &passHost,
+				},
+			},
+		},
+		Routers: map[string]*config.RoutersCfg{
+			"api-router": {
+				Rule: &rule,
+			},
+		},
+	}
+
+	// transport config
+	dialTimeout := time.Second
+	keepAlive := time.Second
+	forceHTTP2 := true
+	maxIdle := 10
+	maxIdlePerHost := 5
+	idleTimeout := 30 * time.Second
+	tlsMin := uint16(0x0303) // TLS1.2
+	tCfg := &config.ProxyTransportCfg{
+		DailTimeout:           &dialTimeout,
+		DailKeepalive:         &keepAlive,
+		ForceHTTP2:            &forceHTTP2,
+		MaxIdleConn:           &maxIdle,
+		MaxIdleConnPerHost:    &maxIdlePerHost,
+		IdleConnTimeout:       &idleTimeout,
+		TLSHandshakeTimeout:   &dialTimeout,
+		ExpectContinueTimeout: &dialTimeout,
+		TLSMinVersion:         &tlsMin,
+	}
+
+	pm.BuildReverseProxy(cfg, tCfg)
+
+	// check proxy exists
+	if rp, ok := pm.GetProxy("api-service"); !ok || rp == nil {
+		t.Fatal("expected proxy for api-service to exist")
+	}
+}
+
+func TestGetProxy_NotFound(t *testing.T) {
+	logg := zaptest.NewLogger(t)
+	pm := NewProxyManger(logg)
+
+	_, ok := pm.GetProxy("unknown")
+	if ok {
+		t.Error("expected no proxy for unknown service")
+	}
+}
+
+func TestReverseProxy_DirectorRewrite(t *testing.T) {
+	logg := zaptest.NewLogger(t)
+	pm := NewProxyManger(logg)
+
+	algo := "round-robin"
+	urlStr := "http://127.0.0.1:8080"
+	flash := 50 * time.Millisecond
+	passHost := true
+	lb := &config.LoadBalancerCfg{
+		Algorithm:      &algo,
+		Servers:        []*config.ServerCfg{{URL: &urlStr}},
+		FlashInterval:  &flash,
+		PassHostHeader: &passHost,
+	}
+
+	dialTimeout := time.Second
+	tlsMin := uint16(0x0303)
+	tCfg := &config.ProxyTransportCfg{
+		DailTimeout:           &dialTimeout,
+		DailKeepalive:         &dialTimeout,
+		ForceHTTP2:            new(bool),
+		MaxIdleConn:           new(int),
+		MaxIdleConnPerHost:    new(int),
+		IdleConnTimeout:       &dialTimeout,
+		TLSHandshakeTimeout:   &dialTimeout,
+		ExpectContinueTimeout: &dialTimeout,
+		TLSMinVersion:         &tlsMin,
+	}
+
+	rp, err := pm.newReverseProxy(tCfg, lb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "http://original/path", nil)
+	rp.Director(req)
+
+	u, _ := url.Parse(urlStr)
+	if req.URL.Host != u.Host {
+		t.Errorf("expected host %s, got %s", u.Host, req.URL.Host)
+	}
+}

--- a/internal/proxy/matchroutes.go
+++ b/internal/proxy/matchroutes.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/asenalabs/asena/internal/config"
+	"go.uber.org/zap"
+)
+
+type matchFunc func(string, *http.Request) bool
+
+var matcherRegistry = map[string]matchFunc{
+	"Host": hostMatcher,
+}
+
+func (pm *Manager) MatchRouter(r *http.Request) (string, bool, error) {
+	value := pm.RouterHolder.Load()
+	routers, ok := value.(map[string]*config.RoutersCfg)
+	if !ok || routers == nil {
+		return "", false, errors.New("no routers configured")
+	}
+
+	for _, router := range routers {
+		if router.Rule == nil {
+			continue
+		}
+		rule := strings.TrimSpace(*router.Rule)
+
+		ok, err := evaluateConditions(rule, r)
+		if err != nil {
+			pm.logg.Warn("Invalid rule", zap.String("rule", rule), zap.Error(err))
+			continue
+		}
+		if ok {
+			if router.Service != nil {
+				return *router.Service, true, nil
+			}
+			pm.logg.Warn("Router matched but service is nil", zap.String("rule", rule))
+			return "", false, nil
+		}
+	}
+	return "", false, nil
+}
+
+func evaluateConditions(rule string, r *http.Request) (bool, error) {
+	rule = strings.TrimSpace(rule)
+
+	open := strings.Index(rule, "(")
+	if open == -1 {
+		return false, errors.New("invalid rule: " + rule)
+	}
+	name := rule[:open]
+
+	matcher, exists := matcherRegistry[name]
+	if !exists {
+		return false, errors.New("unsupported matcher: " + name)
+	}
+
+	return matcher(rule, r), nil
+}
+
+func hostMatcher(cond string, r *http.Request) bool {
+	expected := extractArgument(cond)
+	if expected == "" {
+		return false
+	}
+
+	host := r.Host
+	if strings.Contains(host, ":") {
+		host = strings.Split(host, ":")[0]
+	}
+	return strings.EqualFold(host, expected)
+}
+
+func extractArgument(s string) string {
+	start := strings.Index(s, "(`")
+	end := strings.Index(s, "`)")
+	if start == -1 || end == -1 || end <= start+2 {
+		return ""
+	}
+	return s[start+2 : end]
+}

--- a/internal/proxy/matchroutes_test.go
+++ b/internal/proxy/matchroutes_test.go
@@ -1,0 +1,153 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/asenalabs/asena/internal/config"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestMatchRouter_NoRoutersConfigured(t *testing.T) {
+	pm := NewProxyManger(zaptest.NewLogger(t))
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, ok, err := pm.MatchRouter(req)
+	if err != nil {
+		t.Fatalf("did not expect error, got: %v", err)
+	}
+	if ok {
+		t.Error("expected no match for empty router map")
+	}
+}
+
+func TestMatchRouter_ValidHostRule(t *testing.T) {
+	pm := NewProxyManger(zaptest.NewLogger(t))
+
+	serviceName := "api-service"
+	rule := "Host(`example.com`)"
+	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
+		"api-router": {
+			Rule:    &rule,
+			Service: &serviceName,
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/path", nil)
+	req.Host = "example.com"
+
+	svc, ok, err := pm.MatchRouter(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected rule to match")
+	}
+	if svc != serviceName {
+		t.Errorf("expected service %s, got %s", serviceName, svc)
+	}
+}
+
+func TestMatchRouter_RuleInvalid(t *testing.T) {
+	pm := NewProxyManger(zaptest.NewLogger(t))
+
+	rule := "InvalidRule"
+	service := "api"
+	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
+		"bad-router": {
+			Rule:    &rule,
+			Service: &service,
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, ok, err := pm.MatchRouter(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no match for invalid rule")
+	}
+}
+
+func TestMatchRouter_ServiceNil(t *testing.T) {
+	pm := NewProxyManger(zaptest.NewLogger(t))
+
+	rule := "Host(`example.com`)"
+	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
+		"nil-service-router": {
+			Rule: &rule,
+			// Service deliberately nil
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	svc, ok, err := pm.MatchRouter(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected match to fail since service is nil")
+	}
+	if svc != "" {
+		t.Errorf("expected empty service, got %s", svc)
+	}
+}
+
+func TestEvaluateConditions(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Host = "example.com"
+
+	ok, err := evaluateConditions("Host(`example.com`)", req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected condition to be true")
+	}
+
+	// invalid format
+	_, err = evaluateConditions("Host example.com", req)
+	if err == nil {
+		t.Error("expected error for invalid format")
+	}
+
+	// unsupported matcher
+	_, err = evaluateConditions("Path(`/api`)", req)
+	if err == nil {
+		t.Error("expected error for unsupported matcher")
+	}
+}
+
+func TestHostMatcher(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Host = "example.com"
+
+	if !hostMatcher("Host(`example.com`)", req) {
+		t.Error("expected host to match")
+	}
+
+	// port bilan
+	req.Host = "example.com:8080"
+	if !hostMatcher("Host(`example.com`)", req) {
+		t.Error("expected host to match even with port")
+	}
+
+	// mismatch
+	req.Host = "wrong.com"
+	if hostMatcher("Host(`example.com`)", req) {
+		t.Error("expected host mismatch")
+	}
+}
+
+func TestExtractArgument(t *testing.T) {
+	arg := extractArgument("Host(`example.com`)")
+	if arg != "example.com" {
+		t.Errorf("expected 'example.com', got %s", arg)
+	}
+
+	// invalid format
+	if extractArgument("Host(example.com)") != "" {
+		t.Error("expected empty string for invalid format")
+	}
+}


### PR DESCRIPTION
## Overview

This PR introduces `internal/proxy` and `internal/proxy/balancer` packages.
Together they provide Asena with reverse proxy capabilities, routing rules, and a load balancing mechanism.

## Changes
- [x] Added `proxy.Manager` to hold reverse proxies and routers safely
- [x] Implemented `BuildReverseProxy` for dynamic proxy building from config
- [x] Added rule-based router matching (`Host`)
- [x] Introduced `Balancer` interface and `RoundRobinBalancer` implementation
- [x] Added custom error handler with JSON 502 responses
- [x] Injected security headers in proxied responses
- [x] Added unit tests for proxy building, router matching, and balancing

## Why

Asena requires a flexible reverse proxy core for routing traffic to services.
This PR establishes the foundation for a production-ready reverse proxy with extensible balancing algorithms.

Testing
 - [x] Verified requests are routed based on host/path rules
 - [x] Verified multiple upstreams are balanced with round-robin strategy
 - [x] Verified invalid backends return JSON 502 response
 - [x] Verified Zap logging output for proxy and router lifecycle
 
 Closes #26 