### PR TITLE
Feature/integrate proxy #28

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/asenalabs/asena/internal/config"
+	"github.com/asenalabs/asena/internal/proxy"
 	"github.com/asenalabs/asena/internal/server"
 	"github.com/asenalabs/asena/pkg/logger"
 	"go.uber.org/zap"
@@ -48,9 +49,11 @@ func StartAsena() {
 		logg.Fatal("Failed to initialize dynamic configurations", zap.Error(err))
 	}
 
-	go func() {
-		for _ = range dynamicConfigService.Updates() {
+	pm := proxy.NewProxyManger(logg)
 
+	go func() {
+		for newDCfg := range dynamicConfigService.Updates() {
+			pm.BuildReverseProxy(newDCfg.HTTP, asenaCfg.ProxyTransport)
 		}
 	}()
 

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	version               = "0.1.1"
+	version               = "0.1.2"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "asena.yaml"
 	dynamicConfigFilePath = "dynamic.yaml"


### PR DESCRIPTION
## Overview
This PR integrates the `internal/proxy` package into the `cmd/startasena.go` entrypoint.  
Now the CLI can start Asena with reverse proxy, rule-based routing, and round-robin load balancing.  

## Tasks
- [x] Import `internal/proxy`
- [x] Initialize ProxyManager in `startasena.go`
- [x] Load config and attach to proxy