### PR TITLE
feat (handler): introduce internal/handler with RegisterRoutes (#30)

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/asenalabs/asena/internal/config"
+	"github.com/asenalabs/asena/internal/handler"
 	"github.com/asenalabs/asena/internal/proxy"
 	"github.com/asenalabs/asena/internal/server"
 	"github.com/asenalabs/asena/pkg/logger"
@@ -59,6 +60,7 @@ func StartAsena() {
 
 	//	Local mux
 	mux := http.NewServeMux()
+	handler.RegisterRoutes(pm, mux, logg)
 
 	//	server configurations
 	srvCfg := server.ServerConfig{

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	version               = "0.1.2"
+	version               = "0.1.3"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "asena.yaml"
 	dynamicConfigFilePath = "dynamic.yaml"

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/asenalabs/asena/internal/proxy"
+	"go.uber.org/zap"
+)
+
+func RegisterRoutes(pm *proxy.Manager, mux *http.ServeMux, logg *zap.Logger) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		serviceName, ok, err := pm.MatchRouter(r)
+		if err != nil {
+			logg.Error("failed to match router", zap.Error(err))
+			http.Error(w, "router error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if !ok {
+			logg.Warn("No router found", zap.String("path", r.URL.Path), zap.Error(err))
+			http.NotFound(w, r)
+			return
+		}
+
+		targetProxy, ok := pm.GetProxy(serviceName)
+		if !ok {
+			logg.Warn("No routing rule found for service", zap.String("service", serviceName))
+			http.Error(w, "404 page not found", http.StatusNotFound)
+			return
+		}
+
+		targetProxy.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Overview
Added a new `internal/handler` package that contains `RegisterRoutes`.  
This separates routing logic from `startasena.go` and centralizes HTTP handling.  

## Changes
- Created `internal/handler` package
- Implemented `RegisterRoutes` with proxy manager + Zap logger
- Integrated handler into CLI entrypoint
- Added warnings and error responses for unmatched routes

Closes #30 
