### PR TITLE
Fix/logger sync test #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,59 @@
     asena is a lightweight web server with minimal configuration.
 </p>
 
+---
 
-## 🔹 About
+##  About
 
-**asena** is a minimal configuration web server designed to run independently.
+Asena is a lightweight reverse proxy with minimal configuration. It provides basic host-based routing and load balancing out of the box.
+
+## ✨ Features
+
+* **Reverse Proxy** with `Host(...)` based route matching
+* **Load Balancing** using round-robin algorithm
+* **TLS Support** with hot-reload on certificate changes (SIGHUP)
+* **HTTP Fallback** when TLS is invalid
+* **Structured Logging** with Zap and log rotation via Lumberjack
+* **Configuration** from YAML:
+    * `asena.yaml` → **static** (read once at startup, no hot-reload)
+    * `dynamic.yaml` → **dynamic** (supports hot-reload at runtime)
+
+
+## 📦 Example Configuration
+`dynamic.yaml`:
+```yaml
+http:
+  routers:
+    api-router:
+      rule: "Host(`localhost`)"
+      service: api-service
+
+  services:
+    api-service:
+      load_balancer:
+        algorithm: round-robin
+        servers:
+          - url: "http://localhost:9000"
+          - url: "http://localhost:9001"
+```
+
+## 🚀 Quick Start
+
+```bash
+go run main.go
+```
+
+By default, Asena loads configuration from `asena.yaml` and `dynamic.yaml`.
+
+## 🧪 Tests
+
+```bash
+go test ./...
+```
+
+## 📖 Roadmap
+
+* Support for advanced routing rules (`PathPrefix`, `Method`, `Header`)
+* Middleware support (auth, rate-limit, etc.)
+* Metrics & observability integration
+* Health checks for upstream services

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -52,7 +52,7 @@ func TestGetLoggerReturnsLogger(t *testing.T) {
 func TestSyncDoesNotPanic(t *testing.T) {
 	IntiFallbackZapLogger()
 	defer func() {
-		if r := recover(); r == nil {
+		if r := recover(); r != nil {
 			t.Fatalf("Sync panicked: %v", r)
 		}
 	}()


### PR DESCRIPTION
### 🐞 Problem
The TestSyncDoesNotPanic test in pkg/logger/zap_test.go was failing because
the defer/recover logic was inverted. It expected a panic instead of asserting
that no panic should occur.

### ✅ Fix
- Updated TestSyncDoesNotPanic to assert that Sync() does not panic.

### 📌 Impact
- Test suite passes as expected.

Closes #34 