### PR TITLE
Feature/configwriter: Add YAML config writer and integration with core normalization #45

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	version               = "0.1.9"
+	version               = "0.2.0"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "/etc/asena/asena.yaml"
 	dynamicConfigFilePath = "/etc/asena/dynamic.yaml"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/asenalabs/asena/pkg/cli"
+	"github.com/asenalabs/asena/pkg/configwriter"
 )
 
 // ============================== Static ==============================
@@ -30,9 +31,13 @@ var (
 	ptTLSHandshakeTimeout   = 10 * time.Second
 	ptExpectContinueTimeout = 1 * time.Second
 	ptTLSMinVersion         = uint16(tls.VersionTLS12)
+
+	asenaConfigHeaderComment = `#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#
+#       Asena configuration       #
+#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#`
 )
 
-func setAsenaConfigs(cfg *AsenaConfig) {
+func setAsenaConfigs(cfg *AsenaConfig, asenaConfigFile string) error {
 	if cfg.Asena == nil {
 		cfg.Asena = &AsenaCfg{}
 	}
@@ -52,6 +57,12 @@ func setAsenaConfigs(cfg *AsenaConfig) {
 	normalizeAsenaCfg(cfg.Asena)
 	normalizeLogCfg(cfg.Log)
 	normalizeProxyTransportCfg(cfg.ProxyTransport)
+
+	err := configwriter.WriteConfig(asenaConfigFile, cfg, asenaConfigHeaderComment)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func normalizeAsenaCfg(cfg *AsenaCfg) {

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -48,7 +48,10 @@ func (acs *AsenaConfigService) load() error {
 	}
 
 	//	Set and normalize configurations
-	setAsenaConfigs(&cfg)
+	err = setAsenaConfigs(&cfg, acs.configFilePath)
+	if err != nil {
+		return err
+	}
 
 	acs.cfg = &cfg
 

--- a/pkg/configwriter/writer.go
+++ b/pkg/configwriter/writer.go
@@ -1,0 +1,40 @@
+package configwriter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func WriteConfig(path string, data interface{}, headerComment string) error {
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("directory does not exist: %s", dir)
+	}
+
+	// Open the file with read-write permissions
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0640)
+	if err != nil {
+		return fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer file.Close()
+
+	// Write header comment
+	if headerComment != "" {
+		if _, err := file.WriteString(fmt.Sprintf("%s\n\n", headerComment)); err != nil {
+			return fmt.Errorf("failed to write header comment: %w", err)
+		}
+	}
+
+	// Encode YAML data
+	enc := yaml.NewEncoder(file)
+	enc.SetIndent(2)
+	if err := enc.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode config: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/configwriter/writer_test.go
+++ b/pkg/configwriter/writer_test.go
@@ -1,0 +1,91 @@
+package configwriter
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helper to read file content
+func readFile(t *testing.T, path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	return string(data)
+}
+
+func TestWriteConfig_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "asena.yaml")
+
+	// create the file manually (since WriteConfig expects it to exist)
+	err := os.WriteFile(path, []byte("old: config"), 0640)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg := map[string]interface{}{
+		"port":      8080,
+		"log_level": "info",
+	}
+
+	err = WriteConfig(path, cfg, "# Normalized by Asena")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := readFile(t, path)
+
+	if !strings.HasPrefix(content, "# Normalized by Asena") {
+		t.Errorf("expected header comment, got:\n%s", content)
+	}
+
+	if !strings.Contains(content, "port: 8080") || !strings.Contains(content, "log_level: info") {
+		t.Errorf("expected YAML content not found, got:\n%s", content)
+	}
+}
+
+func TestWriteConfig_DirectoryNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent", "asena.yaml")
+
+	cfg := map[string]interface{}{"port": 8080}
+	err := WriteConfig(path, cfg, "# Test comment")
+
+	if err == nil {
+		t.Fatalf("expected error for nonexistent directory, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "directory does not exist") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestWriteConfig_EmptyHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "asena.yaml")
+
+	err := os.WriteFile(path, []byte("foo: bar"), 0640)
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	cfg := map[string]interface{}{
+		"debug": true,
+	}
+
+	err = WriteConfig(path, cfg, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content := readFile(t, path)
+
+	if strings.HasPrefix(strings.TrimSpace(content), "#") {
+		t.Errorf("expected no comment header, got:\n%s", content)
+	}
+	if !strings.Contains(content, "debug: true") {
+		t.Errorf("expected YAML data, got:\n%s", content)
+	}
+}


### PR DESCRIPTION
### Summary
Introduces a new package `pkg/configwriter` responsible for writing normalized
configurations back into `/etc/asena/asena.yaml`.

### Changes
- Added `pkg/configwriter` with `WriteConfig` function
- Added unit tests for YAML writing
- Integrated `configwriter` into core after config normalization

### Tests
- All tests passing: ✅
- Verified output files contain expected YAML with header comments

### Related Issues
Closes #45 
