### PR TITLE
Fix: migrate director to rewrite to prevent nil panic and IP spoofing #51

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	version               = "0.2.1"
+	version               = "0.2.2"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "/etc/asena/asena.yaml"
 	dynamicConfigFilePath = "/etc/asena/dynamic.yaml"

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -85,24 +85,29 @@ func (pm *Manager) newReverseProxy(t *config.ProxyTransportCfg, l *config.LoadBa
 		},
 	}
 
-	rp.Director = func(req *http.Request) {
+	rp.Rewrite = func(preq *httputil.ProxyRequest) {
 		server := bl.Next()
 		if server == nil || server.URL == nil {
-			pm.logg.Warn("No server available for proxy", zap.String("url", req.URL.String()))
+			pm.logg.Warn("No server available for proxy",
+				zap.String("url", preq.In.URL.String()))
+			return
 		}
 
 		target, err := url.Parse(*server.URL)
 		if err != nil {
-			pm.logg.Warn("Invalid server URL", zap.String("url", *server.URL), zap.Error(err))
+			pm.logg.Warn("Invalid server URL",
+				zap.String("url", *server.URL),
+				zap.Error(err))
 			return
 		}
 
-		req.URL.Scheme = target.Scheme
-		req.URL.Host = target.Host
+		preq.SetURL(target)
 
 		if l.PassHostHeader != nil && *l.PassHostHeader {
-			req.Host = target.Host
+			preq.Out.Host = target.Host
 		}
+
+		preq.SetXForwarded()
 	}
 
 	rp.ModifyResponse = func(resp *http.Response) error {


### PR DESCRIPTION
## Summary
Migrates the deprecated `Director` function to the newer and more secure `Rewrite` API in `httputil.ReverseProxy`.

## Changes
- Replaced `Director` with `Rewrite` in `ReverseProxy`
- Added early `return` on nil server to prevent panic
- Used `preq.SetURL()` instead of manually setting `Scheme` and `Host`
- Used `preq.SetXForwarded()` for safe and correct header forwarding

Closes #51 