### PR TITLE
Fix/match router returns error on empty router #53

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	version               = "0.2.2"
+	version               = "0.2.3"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "/etc/asena/asena.yaml"
 	dynamicConfigFilePath = "/etc/asena/dynamic.yaml"

--- a/internal/proxy/matchroutes.go
+++ b/internal/proxy/matchroutes.go
@@ -19,7 +19,7 @@ func (pm *Manager) MatchRouter(r *http.Request) (string, bool, error) {
 	value := pm.RouterHolder.Load()
 	routers, ok := value.(map[string]*config.RoutersCfg)
 	if !ok || routers == nil {
-		return "", false, errors.New("no routers configured")
+		return "", false, nil
 	}
 
 	for _, router := range routers {


### PR DESCRIPTION
## Summary
`MatchRouter` was returning an error when no routers are configured. 
An empty router map is a normal state at startup, before the first 
dynamic config is loaded.

## Change
```go
// before
if !ok || routers == nil {
    return "", false, errors.New("no routers configured")
}

// after
if !ok || routers == nil {
    return "", false, nil
}
```

Closes  #53 