### PR TITLE
docs: add ADRs for existing design decisions (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.proser

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
-<p align="center">
-  <img src="assets/logo.svg" alt="asena logo" width="350"/>
-</p>
+<img src="assets/logo.svg" alt="asena logo">
+asena is a lightweight web server with minimal configuration.
 
-<p align="center">
-    asena is a lightweight web server with minimal configuration.
-</p>
-
-
-##  🔹 About
+## 🔹 About
 
 Asena is a lightweight reverse proxy with minimal configuration. It provides basic host-based routing and load balancing out of the box.
 
@@ -22,9 +16,10 @@ Asena is a lightweight reverse proxy with minimal configuration. It provides bas
     * `asena.yaml` → **static** (read once at startup, no hot-reload)
     * `dynamic.yaml` → **dynamic** (supports hot-reload at runtime)
 
-
 ## 📦 Example Configuration
+
 `dynamic.yaml`:
+
 ```yaml
 http:
   routers:
@@ -50,10 +45,13 @@ go build -o ./bin/asena
 chmod +x ./scripts/install.sh
 sudo ./scripts/install.sh 
 ```
+
 Copy and paste the above dynamic test configuration into the `/etc/asena/dynamic.yaml` file
+
 ```bash
 sudo -u asena ./bin/asena -http-port :80
 ```
+
 By default, Asena loads configuration from `asena.yaml` and `dynamic.yaml`.
 
 ## 🧪 Tests
@@ -74,3 +72,5 @@ go test ./...
 Contributions are welcome!
 
 Please read the `CONTRIBUTING.md` and `CLA.md` before submitting a pull request.
+
+See [`docs/adr/`](docs/adr/) for the reasons behind key design decisions in this project.

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -30,7 +30,7 @@ func StartAsena() {
 	defer stop()
 
 	//	Initialize basic logger
-	logger.IntiFallbackZapLogger()
+	logger.InitFallbackZapLogger()
 	logg := logger.Get()
 
 	//	Load Asena Configurations

--- a/docs/adr/0001_two_tier_taml_configuration.md
+++ b/docs/adr/0001_two_tier_taml_configuration.md
@@ -1,0 +1,49 @@
+# ADR-001: Two-tier YAML configuration (static + dynamic)
+
+- **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+Asena is a reverse proxy, so it has two very different kinds of setting:
+
+* Settings that rarely change and are risky to change at runtime - the port it listens on, whether HTTPS is enabled, where TLS certs live, how logging is configured.
+* Settings that describe *what traffic goes where* \- routers and backend services\. There need to change often \(adding a service\, adjusting a backend URL\) and restarting the whole proxy every time would cause downtime for anything already routed through it\.
+
+## Decision
+
+Split configuration into two files with two different lifecycles;
+
+* `asena.yaml` - **static**. Read once at startup (`AsenaConfigService`). Holds process-level settings: `asena` (port, TLS), `log`, `proxy_transport`.
+* `dynamic.yaml` - **dynamic**. Watched and hot-reload at runtime (`DynamicConfigService`). Holds `http.routers` and `http.services` \- the actual proxy behavior\.
+
+## Consequensces
+
+**Good:**
+
+* Routing changes take effect without restarting the process or dropping live connections.
+* Clear mental model: "if it's about the process, it's static; if it's about traffic routing, it's dynamic."
+
+**Costs:**
+
+* Two config files and two schemas to document and keep straight (see `docs/DYNAMIC_CONFIG.md` for the dynamic side).
+* Needs its own reload/validation/fallback machinery (see ADR-0005), which is more code than a single flat config file would need.
+
+## Alternatives Considered
+
+* **Single config file, reload everything on change.** Rejected — reloading
+
+things like the listen port or TLS cert paths at runtime is either
+
+meaningless (you can't rebind without restarting anyway) or risky, and it
+
+would make the reload logic more complex for little benefit.
+
+* **Environment variables for everything.** Rejected — the dynamic side
+
+(routers/services, potentially many of them, nested) doesn't map well to
+
+flat env vars.
+
+## Related Code Location
+
+`internal/config/`

--- a/docs/adr/0002_structured_logging_zap_lumberjack.md
+++ b/docs/adr/0002_structured_logging_zap_lumberjack.md
@@ -1,0 +1,35 @@
+# ADR-0002: Structured logging with Zap + Lumberjack
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+As a server handling live traffic, Asena needs structured, leveled logs (not just `fmt.Println`), and it needs log rotation so log files don't grow forever. There's also a chicken-and-egg problem: the *real* logger's settings (output path, rotation, dev vs. prod format) live inside `asena.yaml` but something needs to be able to log errors if loading that very file fails.
+
+## Decision
+
+Use [Zap] (https://github.com/uber-go/zap) for structured logging, in two phases:
+
+1. **`InitFallbackZapLogger()`** \- a bare console logger with no config dependency\, used only until the real config is loaded\.
+2. **`InitProductionZapLogger(env, cfg)`** \- a config\-driven logger\. In [Lumberjack](https://github.com/natefinch/lumberjack); in development it also echoes to the console in a human-readable format.
+
+## Consequences
+
+**Good:**
+
+* Config loading can log real errors (e.g. "failed to read asena config file) before the "real" logger even exists.
+* Startup code doesn't need to pass a logger around before one is ready.
+
+**Costs:**
+
+* `logger.Get()` **panics** if called before either init function has run - there's an implicit ordering dependency (`InitFallbackZapLogger()` or `InitProductionZapLogger()` must run first).
+* A package-level global logger is convenient but implicit - it's harder to swap or mock in tests than an injected logger would be, and any package that imports `pkg/logger` has a hidden dependency on init order.
+
+## Alternatives Considered
+
+* **Dependency-inject a logger everywhere from process start,** Rejected for now - would require restructuring startup to build the logger before anything else and thread it through every constructor. More plumbing than the project needs at its current size; worth revisiting if the global singleton starts causing test pain.
+* **Standard library `log` package.** Rejected - no structured fields or levels, and no rotation without extra glue code.
+
+## Related Code Location
+
+`pkg/logger/`

--- a/docs/adr/0003_stdlib_flag_for_cli.md
+++ b/docs/adr/0003_stdlib_flag_for_cli.md
@@ -1,0 +1,33 @@
+## ADR-0003: Standard library `flag` package for CLI args
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+Asena needs to accept a small number of startup flags: `-http-port`, `-https-port`, `-cert-file`, `-key-file`. Common Go options for this range from the standard library's `flag` package up to full CLI frameworks like [Cobra](https://github.com/spf13/cobra) or [urfave/cli](https://github.com/urfave/cli), which add subcommands, help generation, shell completion, etc.
+
+## Decision
+
+Use the standard library `flag` package, wrapped in a small `pkg/cli.Parse()` helper that returns a plain `Options` structure.
+
+## Consequences
+
+**Good:**
+
+* Zero extra dependencies for something this small.
+* The whole CLI surface is \~20 lines and easy to read end to end.
+
+**Costs:**
+
+* No subcommends (e.g. a future `asena config validate` or `asena version`) without restructuring - \`flag is built around a single flat set of flags.
+* No built-in shell completion or automatic grouped help output the way Cobra/urfave provide.
+* If asena's CLI surface grows significantly, this will likely need to be replaced - that migration is straightforward but not free.
+
+## Alternatives Considered
+
+* **Cobra.** Rejected for now - brings subcommand routing, generated docs, and completion scripts that are overkill for four flags, plus added dependency.
+* **urfave/cli.** Samereasoning as Cobra - more capability than currently needed.
+
+## Related Code Location
+
+`pkg/cli/`

--- a/docs/adr/0004_pluggable_load_balancer.md
+++ b/docs/adr/0004_pluggable_load_balancer.md
@@ -1,0 +1,39 @@
+## ADR-0004: Pluggable load balancer, round-robin default
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+A `service` in `dynamic.yaml` can point at more than one backend server, so Asena needs pick which one handles each request. The project's roadmap already lists more algorithms to come(`weighted-round-robin`, `least-connection`, ...) so the very first algorithm shouldn't be wired in as a one-off.
+
+## Decision
+
+Define a small `Balancer` interface:
+
+```go
+type Balancer interface {
+    Next() config.ServerCfg
+}
+```
+
+and a `New(algorithm, servers)` factory. Today it only implements round-robin, and it also **falls back to round-robin** for any unset or unrecognized `algorithm` value rather than erroring.
+
+## Consequences
+
+**Good:**
+
+* Adding `weight-round-robin` or `least-connection` later means adding a new type that satisfies `Balancer` and one `case` in the factory - call sites don't change.
+* A service always gets a working balanceer, even if `alorithm` is left out of the config entirely.
+
+**Costs:**
+
+* Today, this fallback is safe to have. Before Asena uses an `algorithm` value, `internal/config` checks it first. If the value is missing or wrong, Asena stops and shows an error right there.. So the fallback never actually runs.
+* One small thing to remember: the list of valid algorithm names is written in two places - once in that check, and once inside `balancer.New()`. When we add a new algorithm, we must update both places.
+
+## Alternatives Considered
+
+* **Hardcode round-robin only, no interface.** Rejected - the roadmap already commits to more algorithms, and retrofitting an interface later would mean touching every call site that currently assumes round-robin.
+
+## Related Code Location
+
+`internal/proxy/balancer/`

--- a/docs/adr/0005_dynamic_config_reload_mechanics.md
+++ b/docs/adr/0005_dynamic_config_reload_mechanics.md
@@ -1,0 +1,39 @@
+## ADR-0005: fsnotify-based dynamic config reload
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+`dynamic.yaml` (see ADR-0001) needs to be reloaded automatically when it changes on disk, without downtime. Two practical problems show up as soon as you try this:
+
+1. A single logical "save" from an editor or `mv` often fires *several* filesystem events (write, rename, chmod) -naively reloading on every event means reloading the same content multiple times in a row.
+2. Whatever reads the reloaded config (the proxy manages) shouldn't be able to block the file watcher just by being slow to consume an update.
+
+## Decision
+
+* Watch `dynamic.yaml` with [fsnotify](https://github.com/fsnotify/fsnotify).
+* **Debounce** events for 500ms - if more events arrive within that window, only the last one triggers a reload.
+* **Hash the file** (SHA-256) after parsing and skip publishing an update if the content hash hasn't actually changed since the last reload.
+* Publish new configs on a **buffered channel of size 1** an unconsumed one already sitting in the buffer (last-write-wins) instead of blocking.
+
+## Consequences
+
+**Good:**
+
+* Resilient to editors/tools that touch the file multiple times per save.
+* The watcher loop blocks waiting on a slow or stalled consumer.
+* Reloading unchanged content is a no-op - no unnecessary rebuilds downstream (e.g. the proxy manager doesn't rebuild routes for nothing).
+
+**Costs:**
+
+* A consumer that genuinely needs to see **very** intermediate config state (not just the last) will silently miss updates -this is documented behavior in `docs/DYNAMIC_CONFIG.md`, but it's easy to forget and would need a bigger buffer or a custom fan-out if that requirment ever shows up.
+* The 500ms debounce is a fixed delay between a file save and the change taking effect - small, but worth knowing about if someone is debugging "why didn't my change apply immediately."
+
+## Alternatives Considered
+
+* **Reload on every raw fsnotify event, no debounce.** Rejected - causes redundant reloads and log noise for a single logical save.
+* **Unbuffered channel with a blocking send.** Rejected - would let a slow or stuck consumer stall the entire file watcher goroutine.
+
+## Related Code Location
+
+`internal/config/`

--- a/docs/adr/0006_tls_hot_reload_and_fallback.md
+++ b/docs/adr/0006_tls_hot_reload_and_fallback.md
@@ -1,0 +1,36 @@
+## ADR-0006: TLS hot-reload and fallback to HTTP
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+When HTTPS is enabled, Asena needs to serve TLS certificates that get renewed periodically (e.g. via Let's Encrypt / certbot) - without dropping existing connections or restarting the process. It also needs to decide what happens if TLS is enabled in config but the certificate or key can't actually be loaded at startup.
+
+## Decision
+
+* Load certificates through a `CertManager` and server TLS using a dynamic `GetCertificate` callback (so certs can be swapped without restarting the listener).
+* Listen for **SIGHUP** and reload the cert/key files from the disk in place when reviced - this matches the signal common ACME renewal tooling already sends.
+* If the **initial** certificate load fails, log a warning and **fall back to plain HTTP** instead of refusing to start.
+* When HTTPS is active, also run a small HTTP listener on `:80` whose only job is to redirect everything to HTTPS.
+
+## Consequences
+
+**Good:**
+
+* Certificate rotation doesn't require restarting Asena or dropping in-flight connection.
+* Plays nicely with existing SIGHUP-based renewal workflows.
+* A broken TLS config at boot doesn't take the whole proxy offline - it degrades to HTTP instead of falling to start.
+
+**Costs:**
+
+* That same fallback is a silent one: if TLS is misconfigured, Asena will serve **plain HTTP** on what supposed to be an HTTPS deployment, with only a log line warking the difference. Anyone not watching logs could end up running unencrypted traffic without realizing it - this is a real operational risk worth flagssing to anyone deploying Asena.
+* The HTTP->HTTPS redirect listener's port (`:80`) is hardcoded, not configurable.
+
+## Alternatives Considered
+
+* **Fail fast on bad TLS config at startup.** Rejected (so far) - the project prioritized "the proxy stays up, even degraded" over "refuse to run with a misconfiguration." This trade-off is debatable and could be revisited - e.g. making the fallback-to-HTTP behavior configurable, or at minimum raising it from a `Warn` log to something louder.
+* **Built-in ACME/autocert support.** Not decided - a real option for a future ADR if manual cert management becomes a paint point.
+
+## Related Code Location
+
+`internal/server/`

--- a/docs/adr/0007_atomic_proxy_router_hot_swap.md
+++ b/docs/adr/0007_atomic_proxy_router_hot_swap.md
@@ -1,0 +1,43 @@
+## ADR-0007: Atomic proxy and router hot-swap
+
+* **Status:** Accepted (backfilled - this ADR was written after the code already existed)
+
+## Context
+
+When `dynamic.yaml` changes, the set of routers and reverse proxies inside `proxy.Manager` must be updated without dropping in-flight requests and without restarting the process. ADR-0005 covers *when* a new config is picked up (the file watcher); this ADR covers *how* the proxy actually switches over to it safely while requests are still arriving.
+
+## Decision
+
+`proxy.Manager` stores its current maps of routers and reverse proxies inside an `atomic.Value`. When a new configuration is loaded:
+
+1. A completely new set of proxies and routers is built from scratch.
+2. The new maps are stored atomically, replacing the old ones in one step.
+3. Requests already in flight keep using the old proxies until they finish.
+4. Any new request that arrives after the swap immediately uses the new configuration.
+
+A mutex is used only briefly, during the swap itself - not on the request path.
+
+## Consequences
+
+**Good:**
+
+* Zero-downtime configuration updates - no dropped requests during a reload.
+* Simple and safe for concurrent access: readers on the request path never need to take a lock.
+* No complex locking logic needed where it metters most (the hot request path).
+
+**Costs:**
+
+* Slightly higher memory use during the transition, since the old and new maps briefly exist at the same time.
+* The full set of proxies is rebuilt on every config change, even a small one - there's no partial/incremental update.
+
+**Neutral:**
+
+* This pairs directly with the dynamic config watcher in ADR-0005 - that ADR triggers the reload, this one makes the reload safe to apply while serving traffic.
+
+## Alternatives Considered
+
+* **Mutex around the whole request path.** Rejected - would add lock contention to every single request, not just the rare moment a config reloads.
+
+## Related Code Location
+
+`internal/proxy/`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,8 @@ From now on, try to write the ADR *before* or *while* you build the feature, not
 
 ## How to add a new ADR
 
+Before you start, please read [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for the general rules of this project.
+
 1. Copy `template.md` in this folder.
 2. Give the new file the next number and a short name. Example: `0008-add-rate-limiting.md`
 3. Fill in the sections (see below).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,75 @@
+# Architecture Decision Records (ADRs)
+
+This folder explains **why** Asena is built the way it is. Not what the code does - that's in the code. This folder is about the *reasons* behind the design.
+
+## What is an ADR?
+
+ADR means "Architecture Decision Record." It is one short for one important decision. For example: "why we use Zap for logging" or "why we split the config into two files."
+
+## Why do we use them?
+
+So people don't have to guess. Without this folder, a new contributor would have to read all the code and guess why things were done a certain way. With this folder, they can just read one short file.
+
+Some decisions were already made in the code before this folder existed. Those first ADRs are marked **"Backfilled"**. This means: the decision came first, the ADR was written later, not after.
+
+From now on, try to write the ADR *before* or *while* you build the feature, not after.
+
+## How to add a new ADR
+
+1. Copy `template.md` in this folder.
+2. Give the new file the next number and a short name. Example: `0008-add-rate-limiting.md`
+3. Fill in the sections (see below).
+4. Add a row for it in the **Index** table below.
+5. Open a pull request. If it's a big decision, it's fine to discuss it in an issue first, before writing the full ADR.
+
+## Suggesting a feature or a decision
+
+Do you want to suggest a new feature, or a change to how something works?
+You don't need to write a full ADR yourself. Just open an issue and describe:
+
+* What problem you want to solve
+* Why the current behaviour doesn't solve it
+* Any idea you have for a solution (this part is optional)
+
+If the idea is accepted, and ADR will be written for it (by you or by a maintainer) once the decision is made.
+
+## The section is each ADR
+
+* **Status** — Accepted, Proposed, Backfilled, or Superseded (replaced by
+    a newer ADR)
+* **Context** — What problem were we solving? What made this hard or
+    important?
+* **Decision** — What did we choose to do? Keep it short and direct.
+* **Consequences** — What do we gain? What does it cost us? Every decision
+    has trade-offs — write both sides, not just the good part.
+* **Alternatives Considered** — What other options did we think about, and
+    why did we not pick them?
+* **Related Code Location** *(optional)* — The package or folder where
+    this decision lives (e.g. `internal/config/`). Point to a package, not a
+    specific file or line number — file paths change often, and a stale
+    pointer is worse than none. See ADR-0001 for an example.
+
+Use plain, simple sentences. Many readers of this project are not native English speakers. Short sentences are easier for everyone.
+
+## Index
+
+| # | Title | Status |
+| --- | ----- | ------ |
+| [0001](0001-two-tier-yaml-configuration.md) | Two-tier YAML configuration (static + dynamic) | Backfilled |
+| [0002](0002-structured-logging-zap-lumberjack.md) | Structured logging with Zap + Lumberjack | Backfilled |
+| [0003](0003-stdlib-flag-for-cli.md) | Standard library `flag` package for CLI args | Backfilled |
+| [0004](0004-pluggable-load-balancer.md) | Pluggable load balancer, round-robin default | Backfilled |
+| [0005](0005-dynamic-config-reload-mechanics.md) | fsnotify-based dynamic config reload | Backfilled |
+| [0006](0006-tls-hot-reload-and-fallback.md) | TLS hot-reload and fallback to HTTP | Backfilled |
+| [0007](0007-atomic-proxy-router-hot-swap.md) | Atomic proxy and router hot-swap | Accepted |
+
+## When should I write a new ADR?
+
+Write one when a decision would be hard or confusing to figure out just by reading the code. For example:
+
+* Adding a new dependency
+* Choosing what happens when something fails (a fallback)
+* Picking a file format, protocol, or algorithm
+* Any time someone might reasonably ask "why didn't we just do X instead?"
+
+You do **not** need and ADR for small , everyday coding choices. Save it for decisions that shape the project.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,33 @@
+# ADR-00XX: short title of the decision
+
+* **Status:** Proposed
+
+## Context
+
+What problem are we trying to solve? What makes this hard or important?
+Write 2-4 sentences. Keep it simple.
+
+## Decision
+
+What did we choose to do? One or two sentences, direct and clear.
+
+## Consequences
+
+**Good:**
+
+* What do we gain from this choice?
+
+**Cost:**
+
+* what does it cost us? What gets harder? What are the risks?
+
+Every decision has both. Write both sides.
+
+## Alternatives Considered
+
+* **Option A.** Why we did not pick it.
+* **Option B.** Why we did not pick it.
+
+## Related Code Location
+
+Point to a package, not a specific file or line number (e.g. `internal/config/`).

--- a/pkg/logger/zap.go
+++ b/pkg/logger/zap.go
@@ -18,7 +18,7 @@ type noSyncWriter struct {
 
 var logg *zap.Logger
 
-func IntiFallbackZapLogger() {
+func InitFallbackZapLogger() {
 	var zapCfg zap.Config
 	var encoder zapcore.Encoder
 

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -42,7 +42,7 @@ func TestGetLoggerPanics(t *testing.T) {
 }
 
 func TestGetLoggerReturnsLogger(t *testing.T) {
-	IntiFallbackZapLogger()
+	InitFallbackZapLogger()
 	logg := Get()
 	if logg == nil {
 		t.Fatal("expected non-nil logg")
@@ -50,7 +50,7 @@ func TestGetLoggerReturnsLogger(t *testing.T) {
 }
 
 func TestSyncDoesNotPanic(t *testing.T) {
-	IntiFallbackZapLogger()
+	InitFallbackZapLogger()
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("Sync panicked: %v", r)


### PR DESCRIPTION
## What

Adds `docs/adr/` — Architecture Decision Records for Asena.

- README explaining what ADRs are and how to add new ones
- A template for future ADRs
- 7 backfilled ADRs:
  - Two-tier YAML configuration (static + dynamic)
  - Structured logging (Zap + Lumberjack)
  - CLI parsing (stdlib `flag`)
  - Pluggable load balancer
  - Dynamic config reload mechanics
  - TLS hot-reload and fallback to HTTP
  - Atomic proxy router hot swap
- Links the ADR folder from the main README

## Why

These decisions were already made in code but never written down. This
makes them easier to understand for new contributors and for future me.

Closes (#55)