### PR TITLE
Replace string-based route matching with AST-based rule engine (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<img src="assets/logo.svg" alt="asena logo">
-asena is a lightweight web server with minimal configuration.
-
+<p align="center">
+  <img src="assets/logo.svg" alt="asena logo" width="400">
+</p>
 ## 🔹 About
 
 Asena is a lightweight reverse proxy with minimal configuration. It provides basic host-based routing and load balancing out of the box.
 
 ## ✨ Features
 
-* **Reverse Proxy** with `Host(...)` based route matching
+* **Reverse Proxy** with  rule-based routing - `Host`, `PathPrefix`, `Method`, `Header`, combinable with `&&` / `||` / `!`
 * **Load Balancing** using round-robin algorithm
 * **TLS Support** with hot-reload on certificate changes (SIGHUP)
 * **HTTP Fallback** when TLS is invalid
@@ -62,7 +62,6 @@ go test ./...
 
 ## 📖 Roadmap
 
-* Support for advanced routing rules (`PathPrefix`, `Method`, `Header`)
 * Middleware support (auth, rate-limit, etc.)
 * Metrics & observability integration
 * Health checks for upstream services

--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	version               = "0.2.3"
+	version               = "0.2.4"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "/etc/asena/asena.yaml"
 	dynamicConfigFilePath = "/etc/asena/dynamic.yaml"

--- a/docs/DYNAMIC_CONFIG.md
+++ b/docs/DYNAMIC_CONFIG.md
@@ -22,7 +22,7 @@ Routers define matching rules and map incoming requests to a service.
 
 | Field   | Type   | Description                                                                                                                                                 |
 |---------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| rule    | string | Matching expression (e.g. `Host`, `PathPrefix`, `Method`). Multiple can be combined with `&&` or <code>&#124;</code> (for now there is only `Host` matching)|
+| rule    | string | Matching expression built from one or more matchers, combined with `&&`, <code>&#124;&#124</code>,`!`, and parentheses for grouping. |
 | service | string | Name of the target service (must exist under `services`).                                                                                                   |
 
 #### Examples
@@ -32,10 +32,19 @@ http:
     api-router:
       rule: "Host(`localhost`)"
       service:  api-service
+    api-v2-writes:
+      rule: "Host(`api.example.com`) && PathPrefix(`/v2`) && !Method(`GET`)"
+      service: api-service
 ```
-Supported rule keywords:
-- `Host`
-- *coming soon...*
+Supported matchers:
+- ``Host(`example.com`)`` - matches the request's Host header, ignoring port and letter case.
+- ``PathPrefix(`/v2`)`` - matches when the request path starts with the given prefix.
+- ``Method(`GET`)`` - matches the HTTP method exactly (case-insensitive on input, normalized to uppercase).
+- ``Header(`X-Api-Key`, `secret`)`` - matches when the named header is present with exactly this value.
+
+Matchers can be combined with `&&` (AND), `||` (OR), `!` (NOT), and parentheses for grouping - `&&` binds tighter than `||`, the same as most C-family languages, so use parentheses when you want an OR to span an AND.
+
+When two or more routers' rules could both match the same request, the **more specific** rule wins — roughly: a `Header` match outranks a `Method` match, which outranks `PathPrefix`, which outranks a bare `Host` match, and combining matchers with `&&` always outranks any single one of them alone. This is computed automatically from the rule; you don't configure it directly.
 
 ### 2. Services
 Services define load-balancing to one or more upstream servers.
@@ -89,6 +98,8 @@ Common error messages include:
 ✅ On error:
 - Asena logs the detailed message via `zap.Logger`.
 - The server continues running with the **last valid configuration** to avoid downtime.
+
+**Note on invalid rules specifically:** an unparsable `rule` (e.g. a typo'd matcher name, or unbalanced parentheses) is *not* one of the reload-failing errors above. It's handled one level down: that single router is logged as skipped and excluded from matching, while the rest of a valid `dynamic.yaml` — every other router, and all services — reloads normally. A mistake in one team's router definition doesn't take down anyone else's.
 
 ---
 

--- a/docs/DYNAMIC_CONFIG.md
+++ b/docs/DYNAMIC_CONFIG.md
@@ -22,7 +22,7 @@ Routers define matching rules and map incoming requests to a service.
 
 | Field   | Type   | Description                                                                                                                                                 |
 |---------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| rule    | string | Matching expression built from one or more matchers, combined with `&&`, <code>&#124;&#124</code>,`!`, and parentheses for grouping. |
+| rule    | string | Matching expression built from one or more matchers, combined with `&&`, <code>&#124;&#124;</code>, `!`, and parentheses for grouping. |
 | service | string | Name of the target service (must exist under `services`).                                                                                                   |
 
 #### Examples

--- a/docs/adr/0008_ast_rule_engine.md
+++ b/docs/adr/0008_ast_rule_engine.md
@@ -1,0 +1,48 @@
+## ADR-0008: AST-based rule engine for router matching
+
+* **Status:** Accepted
+
+## Context
+
+Before this change, a router rule like ``Host(`localhost`)`` was matched using simple string search. The code looked for the first `(` in the rule text and used a small map with only one entry: `Host`. This worked, but only for one very simple case.
+
+The roadmap asks for more matchers: `PathPrefix`, `Method`, and `Header`. It also asks for combining them with `&&` (AND), `||` (OR), and `!` (NOT).
+
+This is a problem for simple string search. Once you allow `&&`, `||`, and parenthesis, the same characters can mean different things depending on how they are grouped. For example, `(A || B) && C` and `A || (B && C)` are not the same rule, even though they use the same words. A string search has no way to know which grouping the user meant, it just reads left to right. So we could not just add more `if` checks on top of the old code. We needed a different way to read and understand a rule.
+
+## Decision
+
+We now read a rule in three steps:
+
+1. **Lex** - Turn the rule text into a list of small pieces (tokens). Example: ``Host(`example.com`) && Method(`GET`)`` becomes ``[Host(`example.com`), &&, Method(`GET`)]``.
+2. **Parser** - Turn that list of tokens into a tree. This tree is called AST (Abstract Syntax Tree). The tree remembers grouping and order correctly, so `&&` and `||` never get confused with each other.
+3. **Match** - Walk th tree against each incoming request. Every part of the tree (`Host`, `Method`, `AND`, `OR`, `NOT`, ...) knows how to check itself against a request.
+
+We also give every part of the tree a "specificity" score, a number that says how narrow or exact this rule is. `Header` checks are the most exact, so they get the highest score. A plain `Host` check is less exact, so it gets a lower score. When two rules could both match the same request, the rule with the higher score wins.
+
+All of this reading and scoring happens **one time**, when `dynamic.yaml` is reloaded, not on every single request. After that, matching a real request is fast, we just walk the already-built tree.
+
+If one router's rule is broken (for example, a type in the matcher name), we skip only that router. We write a warning in the logs. The rest of the routers still load and work normally.
+
+## Consequences
+
+**Good:**
+
+* Rules can now use `&&`, `||`, `!`, and `()` correctly, with no confusion about grouping.
+* Adding a new matcher later (for example `ClientIP`) only means adding one small new file. The lexer, the tree, and the matching code do not need to change.
+* Reading and understanding a rule happens only once, at reload time. Answering real requests stays fast, because no text-parsing happens while serving traffic.
+* When two rules could both match, the answer is now always the same, every time. Before, this could depend on random map order in Go, which is confusing and hard to debug.
+
+**Cost:**
+* This is more code than the old version. Instead of one map lookup, we now have a lexer, a tree, and a small parser.
+* The "specificity" score is a rule of thumb, not a strict formula. In most cases it will do what you expect, but a very unusual rule could sort differently than a person expected. This is explained in code comments inside `internal/rule`.
+* A broken rule is now caught when the config reloads, and a warning is printed. This is a good thing, but it is a change in behavior: before, a broken rule would just silently never match.
+
+## Alternatives Considered
+
+* **One big regular expression (regex).** Regex is good at matching text, but it cannot easily handle grouping with `&&`, `||`, and `()` the way a real grammar needs. We would hit the same problem as string search, just written differently.
+* **Add `&&`/`||` on top of the old code, but check them left to right, with no grouping rules.** This was rejected because it has the exact bug described above, it cannot tell `A || B && C` from `(A || B) && C`. This would be a silent correctness bug waiting to happen.
+* **Parse the rule again on every request.** This would be simpler to write, but wasteful, the rule text does not change between config reloads, only the request does. It is better to read the rule once and reuse the result many times, the same idea already used for proxies and routers in ADR-0007.
+
+## Related Code Location
+`internal/rule/`, `internal/proxy/`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,13 +57,14 @@ Use plain, simple sentences. Many readers of this project are not native English
 
 | # | Title | Status |
 | --- | ----- | ------ |
-| [0001](0001-two-tier-yaml-configuration.md) | Two-tier YAML configuration (static + dynamic) | Backfilled |
-| [0002](0002-structured-logging-zap-lumberjack.md) | Structured logging with Zap + Lumberjack | Backfilled |
-| [0003](0003-stdlib-flag-for-cli.md) | Standard library `flag` package for CLI args | Backfilled |
-| [0004](0004-pluggable-load-balancer.md) | Pluggable load balancer, round-robin default | Backfilled |
-| [0005](0005-dynamic-config-reload-mechanics.md) | fsnotify-based dynamic config reload | Backfilled |
-| [0006](0006-tls-hot-reload-and-fallback.md) | TLS hot-reload and fallback to HTTP | Backfilled |
-| [0007](0007-atomic-proxy-router-hot-swap.md) | Atomic proxy and router hot-swap | Accepted |
+| [0001](0001_two_tier_yaml_configuration.md) | Two-tier YAML configuration (static + dynamic) | Backfilled |
+| [0002](0002_structured_logging_zap_lumberjack.md) | Structured logging with Zap + Lumberjack | Backfilled |
+| [0003](0003_stdlib_flag_for_cli.md) | Standard library `flag` package for CLI args | Backfilled |
+| [0004](0004_pluggable_load_balancer.md) | Pluggable load balancer, round-robin default | Backfilled |
+| [0005](0005_dynamic_config_reload_mechanics.md) | fsnotify-based dynamic config reload | Backfilled |
+| [0006](0006_tls_hot_reload_and_fallback.md) | TLS hot-reload and fallback to HTTP | Backfilled |
+| [0007](0007_atomic_proxy_router_hot_swap.md) | Atomic proxy and router hot-swap | Accepted |
+| [0008](0008_ast_rule_engine.md)| AST-based rule engine for router matching | Accepted |
 
 ## When should I write a new ADR?
 

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -28,7 +28,7 @@ func NewProxyManger(logg *zap.Logger) *Manager {
 		logg: logg,
 	}
 	pm.ProxyHolder.Store(make(map[string]*httputil.ReverseProxy))
-	pm.RouterHolder.Store(make(map[string]*config.RoutersCfg))
+	pm.RouterHolder.Store([]Route{})
 
 	return pm
 }
@@ -50,11 +50,8 @@ func (pm *Manager) BuildReverseProxy(cfg *config.HTTPCfg, t *config.ProxyTranspo
 		pm.logg.Info("Reverse proxy built", zap.String("service", name), zap.String("algorithm", *group.LoadBalancer.Algorithm), zap.Int("services_count", len(group.LoadBalancer.Servers)))
 	}
 
-	newRouters := make(map[string]*config.RoutersCfg)
-	for name, router := range cfg.Routers {
-		newRouters[name] = router
-		pm.logg.Info("Router registered", zap.String("router", name), zap.String("rule", *router.Rule))
-	}
+	// Read and sort all rules once, here, at reload time.
+	newRouters := compileRoutes(cfg.Routers, pm.logg)
 
 	pm.mu.Lock()
 	pm.ProxyHolder.Store(newProxies)

--- a/internal/proxy/manager_test.go
+++ b/internal/proxy/manager_test.go
@@ -23,7 +23,7 @@ func TestNewProxyManager_Init(t *testing.T) {
 		t.Error("expected ProxyHolder to contain map[string]*ReverseProxy")
 	}
 
-	if _, ok := pm.RouterHolder.Load().(map[string]*config.RoutersCfg); !ok {
+	if _, ok := pm.RouterHolder.Load().([]Route); !ok {
 		t.Error("expected RouterHolder to contain map[string]*RoutersCfg")
 	}
 }
@@ -34,7 +34,8 @@ func TestBuildReverseProxy_ValidConfig(t *testing.T) {
 	pm := NewProxyManger(logg)
 
 	algo := "round-robin"
-	rule := "Host(`/api`)"
+	rule := "Host(`a.com`)"
+	service := "api-service"
 	flash := 50 * time.Millisecond
 	passHost := true
 	urlStr := "http://127.0.0.1:8080"
@@ -52,7 +53,8 @@ func TestBuildReverseProxy_ValidConfig(t *testing.T) {
 		},
 		Routers: map[string]*config.RoutersCfg{
 			"api-router": {
-				Rule: &rule,
+				Rule:    &rule,
+				Service: &service,
 			},
 		},
 	}
@@ -82,6 +84,15 @@ func TestBuildReverseProxy_ValidConfig(t *testing.T) {
 	// check proxy exists
 	if rp, ok := pm.GetProxy("api-service"); !ok || rp == nil {
 		t.Fatal("expected proxy for api-service to exist")
+	}
+
+	// check route was compiled and stored
+	routes, ok := pm.RouterHolder.Load().([]Route)
+	if !ok {
+		t.Fatalf("expected 1 compiled route, got %d", len(routes))
+	}
+	if routes[0].Name != "api-router" || routes[0].Service != "api-service" {
+		t.Errorf("unexpected compiled route: %+v", routes[0])
 	}
 }
 
@@ -129,11 +140,17 @@ func TestReverseProxy_DirectorRewrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req := httptest.NewRequest("GET", "http://original/path", nil)
-	rp.Director(req)
+	inReq := httptest.NewRequest("GET", "http://original/path", nil)
+	outerReq := inReq.Clone(inReq.Context())
+	preq := &httputil.ProxyRequest{In: inReq, Out: outerReq}
+
+	rp.Rewrite(preq)
 
 	u, _ := url.Parse(urlStr)
-	if req.URL.Host != u.Host {
-		t.Errorf("expected host %s, got %s", u.Host, req.URL.Host)
+	if preq.Out.URL.Host != u.Host {
+		t.Errorf("expected host %s, got %s", u.Host, preq.Out.URL.Host)
+	}
+	if passHost && preq.Out.Host != u.Host {
+		t.Errorf("expected Out.Host %s (PassHostHeader), got %s", u.Host, preq.Out.Host)
 	}
 }

--- a/internal/proxy/matchroutes.go
+++ b/internal/proxy/matchroutes.go
@@ -1,84 +1,26 @@
 package proxy
 
 import (
-	"errors"
 	"net/http"
-	"strings"
-
-	"github.com/asenalabs/asena/internal/config"
-	"go.uber.org/zap"
 )
 
-type matchFunc func(string, *http.Request) bool
-
-var matcherRegistry = map[string]matchFunc{
-	"Host": hostMatcher,
-}
-
+// MatchRouter finds the service name for the first Route whose rule matches r.
+//
+// All the slow work - reading and sorting the rules - already happened once,
+// in compileRoutes, when the config last reloaded. So this function just walks
+// an already-sorted list and checks each one. The list is sorted from most
+// specific to least specific, so the first match is always the right match.
 func (pm *Manager) MatchRouter(r *http.Request) (string, bool, error) {
 	value := pm.RouterHolder.Load()
-	routers, ok := value.(map[string]*config.RoutersCfg)
-	if !ok || routers == nil {
+	routes, ok := value.([]Route)
+	if !ok {
 		return "", false, nil
 	}
 
-	for _, router := range routers {
-		if router.Rule == nil {
-			continue
-		}
-		rule := strings.TrimSpace(*router.Rule)
-
-		ok, err := evaluateConditions(rule, r)
-		if err != nil {
-			pm.logg.Warn("Invalid rule", zap.String("rule", rule), zap.Error(err))
-			continue
-		}
-		if ok {
-			if router.Service != nil {
-				return *router.Service, true, nil
-			}
-			pm.logg.Warn("Router matched but service is nil", zap.String("rule", rule))
-			return "", false, nil
+	for _, route := range routes {
+		if route.Tree.Match(r) {
+			return route.Service, true, nil
 		}
 	}
 	return "", false, nil
-}
-
-func evaluateConditions(rule string, r *http.Request) (bool, error) {
-	rule = strings.TrimSpace(rule)
-
-	open := strings.Index(rule, "(")
-	if open == -1 {
-		return false, errors.New("invalid rule: " + rule)
-	}
-	name := rule[:open]
-
-	matcher, exists := matcherRegistry[name]
-	if !exists {
-		return false, errors.New("unsupported matcher: " + name)
-	}
-
-	return matcher(rule, r), nil
-}
-
-func hostMatcher(cond string, r *http.Request) bool {
-	expected := extractArgument(cond)
-	if expected == "" {
-		return false
-	}
-
-	host := r.Host
-	if strings.Contains(host, ":") {
-		host = strings.Split(host, ":")[0]
-	}
-	return strings.EqualFold(host, expected)
-}
-
-func extractArgument(s string) string {
-	start := strings.Index(s, "(`")
-	end := strings.Index(s, "`)")
-	if start == -1 || end == -1 || end <= start+2 {
-		return ""
-	}
-	return s[start+2 : end]
 }

--- a/internal/proxy/matchroutes_test.go
+++ b/internal/proxy/matchroutes_test.go
@@ -4,9 +4,21 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/asenalabs/asena/internal/config"
+	"github.com/asenalabs/asena/internal/rule"
 	"go.uber.org/zap/zaptest"
 )
+
+// mustParseRule is a small test helper. If the rule string fails to parse,
+// that means the test itself is written wrong, so we fail right away
+// instead of returning an error to check.
+func mustParseRule(t *testing.T, r string) rule.Node {
+	t.Helper()
+	node, err := rule.ParseRule(r)
+	if err != nil {
+		t.Fatalf("test setup: failed to parse rule %q: %v", r, err)
+	}
+	return node
+}
 
 func TestMatchRouter_NoRoutersConfigured(t *testing.T) {
 	pm := NewProxyManger(zaptest.NewLogger(t))
@@ -17,19 +29,19 @@ func TestMatchRouter_NoRoutersConfigured(t *testing.T) {
 		t.Fatalf("did not expect error, got: %v", err)
 	}
 	if ok {
-		t.Error("expected no match for empty router map")
+		t.Error("expected no match for an empty route slice")
 	}
 }
 
 func TestMatchRouter_ValidHostRule(t *testing.T) {
 	pm := NewProxyManger(zaptest.NewLogger(t))
 
-	serviceName := "api-service"
-	rule := "Host(`example.com`)"
-	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
-		"api-router": {
-			Rule:    &rule,
-			Service: &serviceName,
+	pm.RouterHolder.Store([]Route{
+		{
+			Name:    "api-router",
+			Rule:    "Host(`example.com`)",
+			Tree:    mustParseRule(t, "Host(`example.com`)"),
+			Service: "api-service",
 		},
 	})
 
@@ -43,111 +55,61 @@ func TestMatchRouter_ValidHostRule(t *testing.T) {
 	if !ok {
 		t.Fatal("expected rule to match")
 	}
-	if svc != serviceName {
-		t.Errorf("expected service %s, got %s", serviceName, svc)
+	if svc != "api-service" {
+		t.Errorf("expected service api-service, got %s", svc)
 	}
 }
 
-func TestMatchRouter_RuleInvalid(t *testing.T) {
+func TestMatchRouter_NoRouteMatches(t *testing.T) {
 	pm := NewProxyManger(zaptest.NewLogger(t))
 
-	rule := "InvalidRule"
-	service := "api"
-	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
-		"bad-router": {
-			Rule:    &rule,
-			Service: &service,
+	pm.RouterHolder.Store([]Route{
+		{
+			Name:    "api-router",
+			Rule:    "Host(`example.com`)",
+			Tree:    mustParseRule(t, "Host(`example.com`)"),
+			Service: "api-service",
 		},
 	})
 
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	_, ok, err := pm.MatchRouter(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if ok {
-		t.Fatal("expected no match for invalid rule")
-	}
-}
+	req, _ := http.NewRequest("GET", "http://other.com", nil)
+	req.Host = "other.com"
 
-func TestMatchRouter_ServiceNil(t *testing.T) {
-	pm := NewProxyManger(zaptest.NewLogger(t))
-
-	rule := "Host(`example.com`)"
-	pm.RouterHolder.Store(map[string]*config.RoutersCfg{
-		"nil-service-router": {
-			Rule: &rule,
-			// Service deliberately nil
-		},
-	})
-
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
 	svc, ok, err := pm.MatchRouter(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if ok {
-		t.Error("expected match to fail since service is nil")
+		t.Error("expected no match")
 	}
 	if svc != "" {
 		t.Errorf("expected empty service, got %s", svc)
 	}
 }
 
-func TestEvaluateConditions(t *testing.T) {
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	req.Host = "example.com"
+// TestMatchRouter_FirstMatchWinsInStoredOrder checks one simple rule:
+// MatchRouter does NOT sort or compare scores. It just trusts the order
+// it was given. Here we store two routes that would both match, on
+// purpose in the "wrong" order (least specific first), and check that
+// MatchRouter still picks the first one. Real sorting is tested on its
+// own in route_test.go.
+func TestMatchRouter_FirstMatchWinsInStoredOrder(t *testing.T) {
+	pm := NewProxyManger(zaptest.NewLogger(t))
 
-	ok, err := evaluateConditions("Host(`example.com`)", req)
+	pm.RouterHolder.Store([]Route{
+		{Name: "broad", Rule: "PathPrefix(`/`)", Tree: mustParseRule(t, "PathPrefix(`/`)"), Service: "broad-service"},
+		{Name: "narrow", Rule: "PathPrefix(`/api`)", Tree: mustParseRule(t, "PathPrefix(`/api`)"), Service: "narrow-service"},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/api/users", nil)
+	svc, ok, err := pm.MatchRouter(req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !ok {
-		t.Error("expected condition to be true")
+		t.Fatal("expected a match")
 	}
-
-	// invalid format
-	_, err = evaluateConditions("Host example.com", req)
-	if err == nil {
-		t.Error("expected error for invalid format")
-	}
-
-	// unsupported matcher
-	_, err = evaluateConditions("Path(`/api`)", req)
-	if err == nil {
-		t.Error("expected error for unsupported matcher")
-	}
-}
-
-func TestHostMatcher(t *testing.T) {
-	req, _ := http.NewRequest("GET", "http://example.com", nil)
-	req.Host = "example.com"
-
-	if !hostMatcher("Host(`example.com`)", req) {
-		t.Error("expected host to match")
-	}
-
-	// port bilan
-	req.Host = "example.com:8080"
-	if !hostMatcher("Host(`example.com`)", req) {
-		t.Error("expected host to match even with port")
-	}
-
-	// mismatch
-	req.Host = "wrong.com"
-	if hostMatcher("Host(`example.com`)", req) {
-		t.Error("expected host mismatch")
-	}
-}
-
-func TestExtractArgument(t *testing.T) {
-	arg := extractArgument("Host(`example.com`)")
-	if arg != "example.com" {
-		t.Errorf("expected 'example.com', got %s", arg)
-	}
-
-	// invalid format
-	if extractArgument("Host(example.com)") != "" {
-		t.Error("expected empty string for invalid format")
+	if svc != "broad-service" {
+		t.Errorf("expected the FIRST stored route to win regardless of specificity, got %s", svc)
 	}
 }

--- a/internal/proxy/route.go
+++ b/internal/proxy/route.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/asenalabs/asena/internal/config"
+	"github.com/asenalabs/asena/internal/rule"
+	"go.uber.org/zap"
+)
+
+// Route is one router, already fully read and ready to use: the rule text has already been 
+// turned into a rule. Node tree, and its specificity score has already been worked out. 
+// MatchRouter's job on each request is now simple: walk the list, call Tree.Match, stop at
+// the first hit.
+type Route struct {
+	Name        string
+	Rule        string
+	Tree        rule.Node
+	Service     string
+	Specificity int
+}
+
+// compileRoutes turns the raw router config into a list of Route, sorted from most specific 
+// to least specific.
+//
+// We sort once here, when the config reloads, instead of on every request. A config reload 
+// happens rarely, a match happens many times per second. Any work we can do once instead of 
+// every time is worth doing once.
+//
+// If a router has no rule, no service, or a rule that fails to read, we log a warning and 
+// skip just that router. One broken router should not stop the rest of the config from loading.
+func compileRoutes(routers map[string]*config.RoutersCfg, logg *zap.Logger) []Route {
+	routes := make([]Route, 0, len(routers))
+
+	for name, r := range routers {
+		if r.Rule == nil {
+			logg.Warn("Skipping router: rule is nil", zap.String("router", name))
+			continue
+		}
+		if r.Service == nil {
+			logg.Warn("Skipping router: service is nil", zap.String("router", name))
+			continue
+		}
+
+		ruleStr := strings.TrimSpace(*r.Rule)
+		tree, err := rule.ParseRule(ruleStr)
+		if err != nil {
+			logg.Warn("Skipping router: invalid rule",
+				zap.String("router", name), zap.String("rule", ruleStr), zap.Error(err))
+			continue
+		}
+
+		spec := tree.Specificity()
+		routes = append(routes, Route{
+			Name:        name,
+			Rule:        ruleStr,
+			Tree:        tree,
+			Service:     *r.Service,
+			Specificity: spec,
+		})
+		logg.Info("Router compiled",
+			zap.String("router", name), zap.String("rule", ruleStr), zap.Int("specificity", spec))
+	}
+
+	sort.SliceStable(routes, func(i, j int) bool {
+		if routes[i].Specificity != routes[j].Specificity {
+			return routes[i].Specificity > routes[j].Specificity
+		}
+		// If two routes score the same, sort by name. Go's map order is random, so without this,
+		// the winner between two equal routes could change on every reload for no real reason.
+		return routes[i].Name < routes[j].Name
+	})
+
+	return routes
+}

--- a/internal/proxy/route_test.go
+++ b/internal/proxy/route_test.go
@@ -1,0 +1,91 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/asenalabs/asena/internal/config"
+	"go.uber.org/zap/zaptest"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestCompileRoutes_SkipsNilRule(t *testing.T) {
+	routers := map[string]*config.RoutersCfg{
+		"bad": {Service: strPtr("svc")}, // Rule left nil
+	}
+	routes := compileRoutes(routers, zaptest.NewLogger(t))
+	if len(routes) != 0 {
+		t.Errorf("expected a nil-Rule router to be skipped, got %d routes", len(routes))
+	}
+}
+
+func TestCompileRoutes_SkipsNilService(t *testing.T) {
+	routers := map[string]*config.RoutersCfg{
+		"bad": {Rule: strPtr("Host(`a.com`)")}, // Service left nil
+	}
+	routes := compileRoutes(routers, zaptest.NewLogger(t))
+	if len(routes) != 0 {
+		t.Errorf("expected a nil-Service router to be skipped, got %d routes", len(routes))
+	}
+}
+
+func TestCompileRoutes_SkipsInvalidRuleButKeepsOthers(t *testing.T) {
+	// The important behavior here: ONE bad rule in the config must not prevent the other, 
+	// valid routers from being compiled and served.
+	routers := map[string]*config.RoutersCfg{
+		"bad":  {Rule: strPtr("NotAMatcher(`x`)"), Service: strPtr("svc-bad")},
+		"good": {Rule: strPtr("Host(`a.com`)"), Service: strPtr("svc-good")},
+	}
+	routes := compileRoutes(routers, zaptest.NewLogger(t))
+	if len(routes) != 1 {
+		t.Fatalf("expected exactly 1 compiled route, got %d", len(routes))
+	}
+	if routes[0].Name != "good" {
+		t.Errorf("expected the surviving route to be 'good', got %q", routes[0].Name)
+	}
+}
+
+func TestCompileRoutes_SortedMostSpecificFirst(t *testing.T) {
+	routers := map[string]*config.RoutersCfg{
+		"host-only":       {Rule: strPtr("Host(`a.com`)"), Service: strPtr("svc-1")},                  // spec 15
+		"host-and-method": {Rule: strPtr("Host(`a.com`) && Method(`GET`)"), Service: strPtr("svc-2")}, // spec 15+25+10=50
+		"header-only":     {Rule: strPtr("Header(`X-Key`, `v`)"), Service: strPtr("svc-3")},           // spec 30
+	}
+	routes := compileRoutes(routers, zaptest.NewLogger(t))
+	if len(routes) != 3 {
+		t.Fatalf("expected 3 compiled routes, got %d", len(routes))
+	}
+
+	// Descending specificity: host-and-method (50) > header-only (30) > host-only (15).
+	wantOrder := []string{"host-and-method", "header-only", "host-only"}
+	for i, name := range wantOrder {
+		if routes[i].Name != name {
+			t.Errorf("position %d: expected %q, got %q (full order: %+v)", i, name, routes[i].Name, routeNames(routes))
+		}
+	}
+}
+
+func TestCompileRoutes_TieBreaksBySortedName(t *testing.T) {
+	// Both rules score the same (a single Host matcher, 15 either way). So the only thing that 
+	// decides the order is the name tie-break. We run this 20 times to make sure Go's random 
+	// map order can't sneak in and change the result.
+	routers := map[string]*config.RoutersCfg{
+		"zebra": {Rule: strPtr("Host(`z.com`)"), Service: strPtr("svc-z")},
+		"alpha": {Rule: strPtr("Host(`a.com`)"), Service: strPtr("svc-a")},
+	}
+
+	for i := 0; i < 20; i++ {
+		routes := compileRoutes(routers, zaptest.NewLogger(t))
+		if len(routes) != 2 || routes[0].Name != "alpha" || routes[1].Name != "zebra" {
+			t.Fatalf("iteration %d: expected deterministic order [alpha, zebra], got %+v", i, routeNames(routes))
+		}
+	}
+}
+
+func routeNames(routes []Route) []string {
+	names := make([]string, len(routes))
+	for i, r := range routes {
+		names[i] = r.Name
+	}
+	return names
+}

--- a/internal/rule/ast.go
+++ b/internal/rule/ast.go
@@ -1,0 +1,67 @@
+package rule
+
+import "net/http"
+
+// Node is what every part of rule can do, check a request, and say how exact it is.
+// This is true for AndNode, OrNode, and NotNode below, and also for the matcher nodes in matchers.go (HostNode, and so on).
+//
+// Because every part uses the same Node interface, a big tree can be built out of small pieces without any special-case code.
+// An AndNode does not need to know if its children are single matchers or whole sub-trees, it just calls Match on them.
+type Node interface {
+	Match(r *http.Request) bool
+	Specificity() int
+}
+
+// AndNode matches only if both sides match.
+type AndNode struct {
+	Left, Right Node
+}
+
+// Match uses Go's own "&&", so if Left is false, Right is never checked.
+func (n *AndNode) Match(r *http.Request) bool {
+	return n.Left.Match(r) && n.Right.Match(r)
+}
+
+// Specificity adds both sides together, plus 10. The 10 makes an AND always score
+// higher than either side alone, since combining two checks is always more exact than using just one.
+func (n *AndNode) Specificity() int {
+	return n.Left.Specificity() + n.Right.Specificity() + 10
+}
+
+// OrNode matches if either side matches.
+type OrNode struct {
+	Left, Right Node
+}
+
+// Match short-circuits the other way, if Left is true, Right is never checked.
+func (n *OrNode) Match(r *http.Request) bool {
+	return n.Left.Match(r) || n.Right.Match(r)
+}
+
+// Specificity takes the smaller of the two sides, not the sum.
+//
+// Why: "Host(`example.com`) || PathPrefix(`/`)"" is not a tight rule, it matches almost anything, because PathPrefix(`/`)
+// alone matches every path. An OR rule is only as tight as its weakest side, since either side alone is enough to match.
+// Using the smaller score keeps this rule from looking tighter than it really is.
+func (n *OrNode) Specificity() int {
+	l, r := n.Left.Specificity(), n.Right.Specificity()
+	if l < r {
+		return l
+	}
+	return r
+}
+
+// NotNode flips its child's result.
+type NotNode struct {
+	Child Node
+}
+
+func (n *NotNode) Match(r *http.Request) bool {
+	return !n.Child.Match(r)
+}
+
+// Specificity adds a small bonus (5) over the child's score. A NOT is a real extra condition, so it should score
+// a bit higher than the child alone, but it is not a second full condition like AND has, so the bonus is smaller.
+func (n *NotNode) Specificity() int {
+	return n.Child.Specificity() + 5
+}

--- a/internal/rule/ast_test.go
+++ b/internal/rule/ast_test.go
@@ -1,0 +1,137 @@
+package rule
+
+import (
+	"net/http"
+	"testing"
+)
+
+// fakeNode is a test-only Node. Its reasult and score are fixed, and it remembers if Match was ever called.
+// This lets us check that short-circuiting really happens, not just that the final answer is right.
+type fakeNode struct {
+	result  bool
+	spec    int
+	matched bool
+}
+
+func (f *fakeNode) Match(r *http.Request) bool {
+	f.matched = true
+	return f.result
+}
+
+func (f *fakeNode) Specificity() int {
+	return f.spec
+}
+
+func newReq(t *testing.T) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	return r
+}
+
+func TestAndNode_BothTrue(t *testing.T) {
+	left := &fakeNode{result: true}
+	right := &fakeNode{result: true}
+	node := &AndNode{Left: left, Right: right}
+
+	if !node.Match(newReq(t)) {
+
+	}
+}
+
+func TestAndNode_ShortCircuitsOnFalseLeft(t *testing.T) {
+	left := &fakeNode{result: false}
+	right := &fakeNode{result: true}
+	node := &AndNode{Left: left, Right: right}
+
+	if node.Match(newReq(t)) {
+		t.Error("expected AND to fail when left side is false")
+	}
+	if right.matched {
+		t.Error("expected right side to be skipped once left side is false")
+	}
+}
+
+func TestOrNode_ShortCircuitsOnTrueLeft(t *testing.T) {
+	left := &fakeNode{result: true}
+	right := &fakeNode{result: false}
+	node := &OrNode{Left: left, Right: right}
+
+	if !node.Match(newReq(t)) {
+		t.Fatalf("expected OR to match left side is true")
+	}
+	if right.matched {
+		t.Error("expected right side to be skipped once left side is true")
+	}
+}
+
+func TestOrNode_EvaluatesRightWhenLeftFalse(t *testing.T) {
+	left := &fakeNode{result: false}
+	right := &fakeNode{result: true}
+	node := &OrNode{Left: left, Right: right}
+
+	if !node.Match(newReq(t)) {
+		t.Error("expected OR to match via the right side")
+	}
+	if !right.matched {
+		t.Error("expected right side to be evaluated when left is false")
+	}
+}
+
+func TestNotNode_InvertsChild(t *testing.T) {
+	child := &fakeNode{result: true}
+	node := &NotNode{Child: child}
+
+	if node.Match(newReq(t)) {
+		t.Error("expected NOT to invert a true child to false")
+	}
+
+	child.result = false
+	if !node.Match(newReq(t)) {
+		t.Error("expected NOT to invert a false child to ture")
+	}
+}
+
+func TestSpecificity_And_SumsPlusTenBonus(t *testing.T) {
+	node := &AndNode{Left: &fakeNode{spec: 15}, Right: &fakeNode{spec: 22}}
+	if got, want := node.Specificity(), 47; got != want {
+		t.Errorf("AND specificity = %d, want %d", got, want)
+	}
+}
+
+func TestSpecificity_Or_TakesMinimum(t *testing.T) {
+	node := &OrNode{Left: &fakeNode{spec: 24}, Right: &fakeNode{spec: 25}}
+	if got, want := node.Specificity(), 24; got != want {
+		t.Errorf("OR specificity = %d, want %d", got, want)
+	}
+
+	// Order shouldn't matter
+	reversed := &OrNode{Left: &fakeNode{spec: 25}, Right: &fakeNode{spec: 24}}
+	if got, want := reversed.Specificity(), 24; got != want {
+		t.Errorf("OR specificity (reversed operands) = %d, want %d", got, want)
+	}
+}
+
+func TestSpecificity_Not_AddsFiveBonus(t *testing.T) {
+	node := &NotNode{Child: &fakeNode{spec: 25}}
+	if got, want := node.Specificity(), 30; got != want {
+		t.Errorf("NOT specificity = %d, want %d", got, want)
+	}
+}
+
+func TestSpecificity_NestedTree_MatchesWorkedExample(t *testing.T) {
+	// Mirrors "Host(`example.com`) && PathPrefix(`/v2`) && Method(`POST`)"
+	host := &fakeNode{spec: 15}
+	pathPrefix := &fakeNode{spec: 22}
+	method := &fakeNode{spec: 25}
+
+	inner := &AndNode{Left: host, Right: pathPrefix}
+	outer := &AndNode{Left: inner, Right: method}
+
+	if got, want := outer.Specificity(), 82; got != want {
+		t.Errorf("nested AND specificity = %d, want %d", got, want)
+	}
+}

--- a/internal/rule/lexer.go
+++ b/internal/rule/lexer.go
@@ -1,0 +1,106 @@
+package rule
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Lex reads a rule string and splits it into tokens.
+//
+// It does not check if the rule makes sense (like "does && have a left
+// and right side"). It only finds the pieces. Checking if they fit
+// together is the parser's job, in parser.go.
+func Lex(input string) ([]Token, error) {
+	src := strings.TrimSpace(input)
+	var tokens []Token
+	i := 0
+
+	for i < len(src) {
+		switch {
+		case src[i] == ' ' || src[i] == '\t':
+			// Skip blank space.
+			i++
+
+		case strings.HasPrefix(src[i:], "&&"):
+			tokens = append(tokens, Token{AND, "&&"})
+			i += 2
+
+		case strings.HasPrefix(src[i:], "||"):
+			tokens = append(tokens, Token{OR, "||"})
+			i += 2
+
+		case src[i] == '!':
+			tokens = append(tokens, Token{NOT, "!"})
+			i++
+
+		case src[i] == '(':
+			// A matcher call like "Host(`example.com`)" is read whole, in one
+			// go, by the branch below. So if we see a lone "(" here, it
+			// can only be a grouping paren, like in "(A && B)".
+			tokens = append(tokens, Token{LPAREN, "("})
+			i++
+
+		case src[i] == ')':
+			tokens = append(tokens, Token{RPAREN, ")"})
+			i++
+
+		case isIdentStart(src[i]):
+			// Looks like the start of a matcher name, e.g. "Host".
+			tok, next, err := lexFunc(src, i)
+			if err != nil {
+				return nil, err
+			}
+			tokens = append(tokens, tok)
+			i = next
+
+		default:
+			return nil, fmt.Errorf("rule: unexpected character %q at position %d in %q", src[i], i, src)
+		}
+	}
+
+	return tokens, nil
+}
+
+// lexFunc reads one whole matcher call, starting at i, and returns it as
+// one FUNC token: name, parentheses, and the quoted value(s) inside.
+//
+// We count how deep the parentheses go, instead of stopping at the first
+// ")". This way, a value that itself contains parentheses does not cut
+// the call short too early.
+func lexFunc(src string, start int) (Token, int, error) {
+	i := start
+	for i < len(src) && isIdentChar(src[i]) {
+		i++
+	}
+	name := src[start:i]
+
+	if i >= len(src) || src[i] != '(' {
+		return Token{}, 0, fmt.Errorf("rule: expected '(' after matcher name %q in %q", name, src)
+	}
+
+	depth := 0
+	end := i
+	for end < len(src) {
+		switch src[end] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				end++
+				return Token{FUNC, src[start:end]}, end, nil
+			}
+		}
+		end++
+	}
+
+	return Token{}, 0, fmt.Errorf("rule: unclosed parenthesis in %q", src[start:])
+}
+
+func isIdentStart(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isIdentChar(b byte) bool {
+	return isIdentStart(b) || (b >= '0' && b <= '9')
+}

--- a/internal/rule/lexer_test.go
+++ b/internal/rule/lexer_test.go
@@ -1,0 +1,87 @@
+package rule
+
+import "testing"
+
+func TestLex_SingleHostRule(t *testing.T) {
+	tokens, err := Lex("Host(`example.com`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("expected 1 token, got %d: %+v", len(tokens), tokens)
+	}
+	if tokens[0].Type != FUNC || tokens[0].Value != "Host(`example.com`)" {
+		t.Errorf("unexpected token: %+v", tokens[0])
+	}
+}
+
+func TestLex_CompoundRule(t *testing.T) {
+	// Mirrors the worked example from the design doc.
+	tokens, err := Lex("Host(`example.com`) && (PathPrefix(`/v2`) || !Method(`DELETE`))")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []Token{
+		{FUNC, "Host(`example.com`)"},
+		{AND, "&&"},
+		{LPAREN, "("},
+		{FUNC, "PathPrefix(`/v2`)"},
+		{OR, "||"},
+		{NOT, "!"},
+		{FUNC, "Method(`DELETE`)"},
+		{RPAREN, ")"},
+	}
+
+	if len(tokens) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %+v", len(want), len(tokens), tokens)
+	}
+	for i, tok := range tokens {
+		if tok != want[i] {
+			t.Errorf("token %d: expected %+v, got %+v", i, want[i], tok)
+		}
+	}
+}
+
+func TestLex_NestedParensInArgument(t *testing.T) {
+	// A pathological but valid input: the argument itself contains parens.
+	// This exercises the depth-counting logic in lexFunc directly.
+	tokens, err := Lex("Header(`X-Debug`, `(on)`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].Value != "Header(`X-Debug`, `(on)`)" {
+		t.Errorf("unexpected result: %+v", tokens)
+	}
+}
+
+func TestLex_UnclosedParenthesis(t *testing.T) {
+	_, err := Lex("Host(`example.com`")
+	if err == nil {
+		t.Fatal("expected an error for unclosed parenthesis")
+	}
+}
+
+func TestLex_MissingParenAfterName(t *testing.T) {
+	_, err := Lex("Host `example.com`")
+	if err == nil {
+		t.Fatal("expected an error for a matcher name with no '(' following it")
+	}
+}
+
+func TestLex_UnexpectedCharacter(t *testing.T) {
+	_, err := Lex("Host(`example.com`) & Method(`GET`)")
+	if err == nil {
+		t.Fatal("expected an error for a stray single '&'")
+	}
+}
+
+func TestLex_WhitespaceIsSkipped(t *testing.T) {
+	tokens, err := Lex("   Host(`example.com`)   &&   Method(`GET`)  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tokens) != 3 {
+		t.Fatalf("expected 3 tokens, got %d: %+v", len(tokens), tokens)
+	}
+}

--- a/internal/rule/matcher.go
+++ b/internal/rule/matcher.go
@@ -1,0 +1,153 @@
+package rule
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// buildLeaf turns one matcher call, like "Host(`example.com`)", into a real matcher. This is the 
+// one place that turns a name into a type, so it is also the best place to give a clear error for 
+// a bad name or a wrong number of arguments.
+func buildLeaf(raw string) (Node, error) {
+	name, args, err := parseFunc(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	switch name {
+	case "Host":
+		if len(args) != 1 {
+			return nil, fmt.Errorf("rule: Host expects exactly 1 argument, got %d in %q", len(args), raw)
+		}
+		// Lowercase it once, here, so Match never has to think about case.
+		return &HostNode{host: strings.ToLower(args[0])}, nil
+
+	case "PathPrefix":
+		if len(args) != 1 {
+			return nil, fmt.Errorf("rule: PathPrefix expects exactly 1 argument, got %d in %q", len(args), raw)
+		}
+		return &PathPrefixNode{prefix: args[0]}, nil
+
+	case "Method":
+		if len(args) != 1 {
+			return nil, fmt.Errorf("rule: Method expects exactly 1 argument, got %d in %q", len(args), raw)
+		}
+		return &MethodNode{method: strings.ToUpper(args[0])}, nil
+
+	case "Header":
+		if len(args) != 2 {
+			return nil, fmt.Errorf("rule: Header expects exactly 2 arguments (key, value), got %d in %q", len(args), raw)
+		}
+		return &HeaderNode{key: args[0], val: args[1]}, nil
+
+	default:
+		return nil, fmt.Errorf("rule: unknown matcher %q in %q (supported: Host, PathPrefix, Method, Header)", name, raw)
+	}
+}
+
+// HostNode matches the request's Host header. It ignores the port and the letter case,
+// since hostnames don't care about case, and the port is often present even when
+// the operator only means the name.
+type HostNode struct{ host string }
+
+func (n *HostNode) Match(r *http.Request) bool {
+	h := strings.ToLower(r.Host)
+	if i := strings.IndexByte(h, ':'); i != -1 {
+		h = h[:i]
+	}
+	return h == n.host
+}
+
+// Specificity, a Host match only narrows down which site. It says nothing about which
+// path, method, or header - so it scores lower than the others below.
+func (n *HostNode) Specificity() int { return 15 }
+
+// PathPrefixNode matches when the request path starts with prefix.
+type PathPrefixNode struct{ prefix string }
+
+func (n *PathPrefixNode) Match(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, n.prefix)
+}
+
+// Specificity grows with the length of the prefix. "/api/v2/users" is a
+// much narrower claim than "/", even though both use PathPrefix. If we
+// gave every PathPrefix the same flat score, a short, broad prefix and
+// a long, exact one would look equally specific, which is wrong.
+func (n *PathPrefixNode) Specificity() int { return 20 + len(n.prefix) }
+
+// MethodNode matches the HTTP method (GET, POST, ...).
+type MethodNode struct{ method string }
+
+func (n *MethodNode) Match(r *http.Request) bool { return r.Method == n.method }
+
+// Specificity, there are only a few HTTP methods in real use, so a Method match rules out more
+// traffic than a Host match usually does, most setups have far more hostnames than methods.
+func (n *MethodNode) Specificity() int { return 25 }
+
+// HeaderNode matches when the named header has exactly this value.
+type HeaderNode struct{ key, val string }
+
+func (n *HeaderNode) Match(r *http.Request) bool {
+	// Header.Get already ignores letter case on the key.
+	return r.Header.Get(n.key) == n.val
+}
+
+// Specificity is the highest of the four. A header match needs the caller to know and send an
+// exact value, so it's the narrowest and most deliberate check a request can carry.
+func (n *HeaderNode) Specificity() int { return 30 }
+
+// parseFunc splits a matcher call, like "Host(`example.com`)", into its
+// name ("Host") and its arguments (["example.com"]).
+func parseFunc(raw string) (name string, args []string, err error) {
+	open := strings.IndexByte(raw, '(')
+	if open == -1 || raw[len(raw)-1] != ')' {
+		// This should never happen, the lexer already checked the shape.
+		return "", nil, fmt.Errorf("rule: malformed matcher call %q", raw)
+	}
+	name = raw[:open]
+	inner := raw[open+1 : len(raw)-1]
+
+	args, err = parseArgs(inner)
+	if err != nil {
+		return "", nil, fmt.Errorf("rule: %w in %q", err, raw)
+	}
+	return name, args, nil
+}
+
+// parseArgs splits the text inside a matcher's parentheses into separate, unquoted arguments.
+//
+// A plain split on "," would break the day a value has a comma inside it, like Header(`X-Roles`, `admin,editor`).
+// So we only treat, "," as a separator when we are not inside backticks.
+func parseArgs(inner string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	inBacktick := false
+
+	for i := 0; i < len(inner); i++ {
+		c := inner[i]
+		switch {
+		case c == '`':
+			inBacktick = !inBacktick
+			current.WriteByte(c)
+		case c == ',' && !inBacktick:
+			args = append(args, strings.TrimSpace(current.String()))
+			current.Reset()
+		default:
+			current.WriteByte(c)
+		}
+	}
+	if inBacktick {
+		return nil, fmt.Errorf("unterminated backtick in argument list")
+	}
+	args = append(args, strings.TrimSpace(current.String()))
+
+	unquoted := make([]string, len(args))
+	for i, a := range args {
+		if len(a) < 2 || a[0] != '`' || a[len(a)-1] != '`' {
+			return nil, fmt.Errorf("argument %q is not backtick-quoted", a)
+		}
+		unquoted[i] = a[1 : len(a)-1]
+	}
+	return unquoted, nil
+}

--- a/internal/rule/matcher_test.go
+++ b/internal/rule/matcher_test.go
@@ -1,0 +1,115 @@
+package rule
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHostNode_MatchIgnoresPortAndCase(t *testing.T) {
+	node := &HostNode{host: "example.com"}
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"example.com", true},
+		{"EXAMPLE.COM", true},
+		{"example.com:8080", true},
+		{"other.com", false},
+	}
+	for _, c := range cases {
+		r := &http.Request{Host: c.host}
+		if got := node.Match(r); got != c.want {
+			t.Errorf("Host=%q: Match() = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+func TestPathPrefixNode_Match(t *testing.T) {
+	node := &PathPrefixNode{prefix: "/api/v2"}
+
+	r, _ := http.NewRequest("GET", "http://x/api/v2/users", nil)
+	if !node.Match(r) {
+		t.Error("expected /api/v2/users to match prefix /api/v2")
+	}
+
+	r2, _ := http.NewRequest("GET", "http://x/api/v1/users", nil)
+	if node.Match(r2) {
+		t.Error("expected /api/v1/users NOT to match prefix /api/v2")
+	}
+}
+
+func TestPathPrefixNode_SpecificityGrowsWithLength(t *testing.T) {
+	short := &PathPrefixNode{prefix: "/api"}
+	long := &PathPrefixNode{prefix: "/api/v2/users"}
+	if long.Specificity() <= short.Specificity() {
+		t.Errorf("expected longer prefix to score higher: short=%d long=%d",
+			short.Specificity(), long.Specificity())
+	}
+}
+
+func TestMethodNode_Match(t *testing.T) {
+	node := &MethodNode{method: "POST"}
+	r, _ := http.NewRequest("POST", "http://x/", nil)
+	if !node.Match(r) {
+		t.Error("expected POST request to match Method(`POST`)")
+	}
+	r2, _ := http.NewRequest("GET", "http://x/", nil)
+	if node.Match(r2) {
+		t.Error("expected GET request NOT to match Method(`POST`)")
+	}
+}
+
+func TestHeaderNode_MatchIsKeyCaseInsensitive(t *testing.T) {
+	node := &HeaderNode{key: "X-Api-Key", val: "secret123"}
+	r, _ := http.NewRequest("GET", "http://x/", nil)
+	r.Header.Set("x-api-key", "secret123") // client sent lowercase
+
+	if !node.Match(r) {
+		t.Error("expected header match to be case-insensitive on the key")
+	}
+
+	r.Header.Set("x-api-key", "wrong")
+	if node.Match(r) {
+		t.Error("expected mismatched header value NOT to match")
+	}
+}
+
+func TestBuildLeaf_UnknownMatcher(t *testing.T) {
+	_, err := buildLeaf("Frobnicate(`x`)")
+	if err == nil {
+		t.Fatal("expected an error for an unknown matcher name")
+	}
+}
+
+func TestBuildLeaf_WrongArgCount(t *testing.T) {
+	_, err := buildLeaf("Host(`a.com`, `b.com`)")
+	if err == nil {
+		t.Fatal("expected an error: Host takes exactly 1 argument")
+	}
+}
+
+func TestParseArgs_CommaInsideBacktickIsPreserved(t *testing.T) {
+	// The exact case that a naive strings.Split(s, ",") would break.
+	args, err := parseArgs("`X-Roles`, `admin,editor`")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[0] != "X-Roles" || args[1] != "admin,editor" {
+		t.Errorf("unexpected args: %+v", args)
+	}
+}
+
+func TestParseArgs_UnterminatedBacktick(t *testing.T) {
+	_, err := parseArgs("`unterminated")
+	if err == nil {
+		t.Fatal("expected an error for an unterminated backtick")
+	}
+}
+
+func TestParseArgs_NotBacktickQuoted(t *testing.T) {
+	_, err := parseArgs("bareword")
+	if err == nil {
+		t.Fatal("expected an error for an argument with no backticks")
+	}
+}

--- a/internal/rule/parser.go
+++ b/internal/rule/parser.go
@@ -1,0 +1,146 @@
+package rule
+
+import "fmt"
+
+// ParseRule turns a rule string into a Node tree, ready to check
+// requests against.
+//
+// It reads the rule in this order, from loosest to tightest:
+//
+//	parseOr    -> handles "||"
+//	parseAnd   -> handles "&&"
+//	parseUnary -> handles "!"
+//	parsePrimary -> one matcher call, or "( ... )"
+//
+// Each step calls the next step first, before looking for its own
+// operator. This is what makes "&&" bind tighter than "||", the same as
+// in Go itself: "A || B && C" becomes "A || (B && C)", because parseOr's
+// right side comes from parseAnd, and parseAnd already grabs "B && C" as
+// one piece before parseOr ever sees the "||".
+func ParseRule(raw string) (Node, error) {
+	tokens, err := Lex(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("rule: empty rule")
+	}
+
+	p := &parser{tokens: tokens}
+	node, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+
+	// A good rule uses every token. Anything left over means there was
+	// extra text after a complete rule, like two matchers with no
+	// operator between them.
+	if p.pos != len(p.tokens) {
+		return nil, fmt.Errorf("rule: unexpected token %q after end of expression in %q", p.tokens[p.pos].Value, raw)
+	}
+	return node, nil
+}
+
+// parser walks the token list with one cursor. This grammar never needs
+// to go back, so a simple index is enough.
+type parser struct {
+	tokens []Token
+	pos    int
+}
+
+// peek looks at the current token without moving past it. It returns
+// false if there are no tokens left.
+func (p *parser) peek() (Token, bool) {
+	if p.pos >= len(p.tokens) {
+		return Token{}, false
+	}
+	return p.tokens[p.pos], true
+}
+
+func (p *parser) parseOr() (Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		tok, ok := p.peek()
+		if !ok || tok.Type != OR {
+			break
+		}
+		p.pos++
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &OrNode{Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (Node, error) {
+	left, err := p.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		tok, ok := p.peek()
+		if !ok || tok.Type != AND {
+			break
+		}
+		p.pos++
+		right, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = &AndNode{Left: left, Right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseUnary() (Node, error) {
+	tok, ok := p.peek()
+	if ok && tok.Type == NOT {
+		p.pos++
+		// Calling parseUnary again (not parsePrimary) lets "!!Host(...)" parse too. 
+		// Nobody writes that on purpose, but it comes for free this way, so there is 
+		// no need to block it.
+		child, err := p.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return &NotNode{Child: child}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Node, error) {
+	tok, ok := p.peek()
+	if !ok {
+		return nil, fmt.Errorf("rule: unexpected end of expression")
+	}
+
+	switch tok.Type {
+	case FUNC:
+		p.pos++
+		return buildLeaf(tok.Value)
+
+	case LPAREN:
+		p.pos++
+		// Going back to parseOr here is what makes parentheses able to override the normal order,
+		// whatever is inside "(...)" is read as its own full rule, then treated as one single 
+		// piece by whoever called us.
+		node, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		closeTok, ok := p.peek()
+		if !ok || closeTok.Type != RPAREN {
+			return nil, fmt.Errorf("rule: expected ')' to close group")
+		}
+		p.pos++
+		return node, nil
+
+	default:
+		return nil, fmt.Errorf("rule: unexpected token %q", tok.Value)
+	}
+}

--- a/internal/rule/parser_test.go
+++ b/internal/rule/parser_test.go
@@ -1,0 +1,138 @@
+package rule
+
+import (
+	"net/http"
+	"testing"
+)
+
+func req(t *testing.T, method, host, path string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(method, "http://"+host+path, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	return r
+}
+
+func TestParseRule_SingleMatcher(t *testing.T) {
+	node, err := ParseRule("Host(`example.com`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !node.Match(req(t, "GET", "example.com", "/")) {
+		t.Error("expected example.com to match")
+	}
+	if node.Match(req(t, "GET", "other.com", "/")) {
+		t.Error("expected other.com NOT to match")
+	}
+}
+
+func TestParseRule_And(t *testing.T) {
+	node, err := ParseRule("Host(`example.com`) && Method(`POST`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !node.Match(req(t, "POST", "example.com", "/")) {
+		t.Error("expected Host+Method match to succeed")
+	}
+	if node.Match(req(t, "GET", "example.com", "/")) {
+		t.Error("expected mismatched method to fail the AND")
+	}
+}
+
+// This is the most important test in this file. It proves "&&" binds
+// tighter than "||", the same as in Go, instead of just reading left to
+// right.
+//
+// Rule: Method(`GET`) || Method(`POST`) && Host(`nope.com`)
+//
+// Right way:  GET || (POST && Host(nope))
+// Wrong way:  (GET || POST) && Host(nope)
+//
+// A GET request shows the difference. With the right grouping, GET
+// matches right away, no matter the host. With the wrong grouping, GET
+// would also need Host(`nope.com`) to be true - which it is not here. So
+// a bug in precedence would flip this test's result.
+func TestParseRule_AndBindsTighterThanOr(t *testing.T) {
+	node, err := ParseRule("Method(`GET`) || Method(`POST`) && Host(`nope.com`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !node.Match(req(t, "GET", "real.com", "/")) {
+		t.Error("expected GET to match via the left OR branch regardless of host")
+	}
+	if node.Match(req(t, "POST", "real.com", "/")) {
+		t.Error("expected POST to real.com NOT to match: right branch requires Host(`nope.com`)")
+	}
+	if !node.Match(req(t, "POST", "nope.com", "/")) {
+		t.Error("expected POST to nope.com to match via the right AND branch")
+	}
+}
+
+func TestParseRule_ParensOverridePrecedence(t *testing.T) {
+	// Same tokens as above, but explicit grouping now requires Host to
+	// match no matter which method is used.
+	node, err := ParseRule("(Method(`GET`) || Method(`POST`)) && Host(`real.com`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !node.Match(req(t, "GET", "real.com", "/")) {
+		t.Error("expected GET to real.com to match")
+	}
+	if node.Match(req(t, "GET", "other.com", "/")) {
+		t.Error("expected GET to other.com NOT to match: grouped OR still needs Host(`real.com`)")
+	}
+}
+
+func TestParseRule_Not(t *testing.T) {
+	node, err := ParseRule("Host(`example.com`) && !Method(`DELETE`)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !node.Match(req(t, "GET", "example.com", "/")) {
+		t.Error("expected non-DELETE request to example.com to match")
+	}
+	if node.Match(req(t, "DELETE", "example.com", "/")) {
+		t.Error("expected DELETE request to example.com NOT to match")
+	}
+}
+
+func TestParseRule_DeeplyNestedFromDesignDoc(t *testing.T) {
+	node, err := ParseRule("Host(`example.com`) && (PathPrefix(`/v2`) || !Method(`DELETE`))")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Wrong host: never matches, regardless of the right-hand side.
+	if node.Match(req(t, "GET", "other.com", "/v2/x")) {
+		t.Error("expected wrong host NOT to match")
+	}
+	// Right host, path under /v2: matches via PathPrefix.
+	if !node.Match(req(t, "DELETE", "example.com", "/v2/x")) {
+		t.Error("expected /v2 path to match via PathPrefix even on DELETE")
+	}
+	// Right host, path outside /v2, non-DELETE: matches via !Method(DELETE).
+	if !node.Match(req(t, "GET", "example.com", "/v1/x")) {
+		t.Error("expected non-/v2 GET to match via the NOT branch")
+	}
+	// Right host, path outside /v2, DELETE: both OR branches fail.
+	if node.Match(req(t, "DELETE", "example.com", "/v1/x")) {
+		t.Error("expected non-/v2 DELETE NOT to match either OR branch")
+	}
+}
+
+func TestParseRule_Errors(t *testing.T) {
+	cases := []string{
+		"Host(`a.com`) &&",            // dangling operator
+		"(Host(`a.com`)",              // unclosed group
+		"Host(`a.com`) Host(`b.com`)", // missing operator between two exprs
+		"Frobnicate(`x`)",             // unknown matcher
+		"",                            // empty rule
+	}
+	for _, rule := range cases {
+		if _, err := ParseRule(rule); err == nil {
+			t.Errorf("ParseRule(%q): expected an error, got nil", rule)
+		}
+	}
+}

--- a/internal/rule/token.go
+++ b/internal/rule/token.go
@@ -1,0 +1,27 @@
+package rule
+
+// TokenType says what kind of token this is.
+type TokenType int
+
+const (
+	// AND is "&&".
+	AND TokenType = iota
+	// OR is "||".
+	OR
+	// NOT is "!".
+	NOT
+	// LPAREN is "(".
+	LPAREN
+	// RPAREN is ")".
+	RPAREN
+	// FUNC is one full matcher call, like "Host(`example.com`)".
+	FUNC
+)
+
+// Token is one small piece of a rule.
+type Token struct {
+	Type TokenType
+	// Value is the original text, like "&&" or "Host(`example.com`)".
+	// We keep it so error messages can show the user's own words.
+	Value string
+}


### PR DESCRIPTION
## What changed

- New `internal/rule` package: lexer, AST, matchers, parser.
- `Host`, `PathPrefix`, `Method`, `Header` matchers, combinable with
  `&&`, `||`, `!`, and `()`.
- Rules are read once per config reload, not once per request.
- Routes are sorted by how specific they are, so the most exact rule
  wins when two rules could both match.
- A broken rule in one router is skipped with a warning log. It does
  not break the rest of the config.

## Why
See #57 and `docs/adr/0008_ast_rule_engine.md`.

## Testing
- `go test ./internal/rule/...`
- `go test ./internal/proxy/...`

Closes #57 