### PR TITLE
Fix panic: flag redefined when loading Asena config more than once (#59)

### DIFF
--- a/cmd/startasena.go
+++ b/cmd/startasena.go
@@ -13,12 +13,13 @@ import (
 	"github.com/asenalabs/asena/internal/middleware"
 	"github.com/asenalabs/asena/internal/proxy"
 	"github.com/asenalabs/asena/internal/server"
+	"github.com/asenalabs/asena/pkg/cli"
 	"github.com/asenalabs/asena/pkg/logger"
 	"go.uber.org/zap"
 )
 
 var (
-	version               = "0.2.4"
+	version               = "0.2.5"
 	env                   = "development" //	development | production
 	asenaConfigFilePath   = "/etc/asena/asena.yaml"
 	dynamicConfigFilePath = "/etc/asena/dynamic.yaml"
@@ -33,8 +34,11 @@ func StartAsena() {
 	logger.InitFallbackZapLogger()
 	logg := logger.Get()
 
+	// Parse CLI flags once, at startup
+	cliOpts := cli.Parse()
+
 	//	Load Asena Configurations
-	asenaConfigService, err := config.NewAsenaConfigService(asenaConfigFilePath, logg)
+	asenaConfigService, err := config.NewAsenaConfigService(asenaConfigFilePath, cliOpts, logg)
 	if err != nil {
 		logg.Fatal("Failed to initialize Asena configurations", zap.Error(err))
 	}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -37,7 +37,7 @@ var (
 #-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#-#`
 )
 
-func setAsenaConfigs(cfg *AsenaConfig, asenaConfigFile string) error {
+func setAsenaConfigs(cfg *AsenaConfig, asenaConfigFile string, cliOpts *cli.Options) error {
 	if cfg.Asena == nil {
 		cfg.Asena = &AsenaCfg{}
 	}
@@ -51,8 +51,7 @@ func setAsenaConfigs(cfg *AsenaConfig, asenaConfigFile string) error {
 		cfg.ProxyTransport = &ProxyTransportCfg{}
 	}
 
-	cliOptions := cli.Parse()
-	setVariablesGotFromCLI(cliOptions)
+	setVariablesGotFromCLI(cliOpts)
 
 	normalizeAsenaCfg(cfg.Asena)
 	normalizeLogCfg(cfg.Log)

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/asenalabs/asena/pkg/cli"
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -21,11 +22,13 @@ type AsenaConfigService struct {
 	cfg            *AsenaConfig
 	logg           *zap.Logger
 	configFilePath string
+	cliOpts        *cli.Options
 }
 
-func NewAsenaConfigService(configFilePath string, logg *zap.Logger) (*AsenaConfigService, error) {
+func NewAsenaConfigService(configFilePath string, cliOpts *cli.Options, logg *zap.Logger) (*AsenaConfigService, error) {
 	acs := &AsenaConfigService{
 		configFilePath: configFilePath,
+		cliOpts:        cliOpts,
 		logg:           logg,
 	}
 
@@ -48,7 +51,7 @@ func (acs *AsenaConfigService) load() error {
 	}
 
 	//	Set and normalize configurations
-	err = setAsenaConfigs(&cfg, acs.configFilePath)
+	err = setAsenaConfigs(&cfg, acs.configFilePath, acs.cliOpts)
 	if err != nil {
 		return err
 	}

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asenalabs/asena/pkg/cli"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
@@ -31,7 +32,7 @@ proxy_transport: {}
 		}
 	}()
 
-	svc, err := NewAsenaConfigService(tmpFile, zap.NewNop())
+	svc, err := NewAsenaConfigService(tmpFile, &cli.Options{}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewAsenaConfigService() failed: %v", err)
 	}
@@ -64,7 +65,7 @@ asena:
 		}
 	}()
 
-	svc, err := NewAsenaConfigService(tmpFile, zap.NewNop())
+	svc, err := NewAsenaConfigService(tmpFile, &cli.Options{}, zap.NewNop())
 	if err != nil {
 		t.Fatalf("NewAsenaConfigService() failed: %v", err)
 	}

--- a/pkg/cli/parser.go
+++ b/pkg/cli/parser.go
@@ -16,19 +16,20 @@ type Options struct {
 func Parse() *Options {
 	var opts Options
 
-	flag.StringVar(&opts.PortHTTP, "http-port", "", "HTTP port for Asena")
-	flag.StringVar(&opts.PortHTTPS, "https-port", "", "HTTPS port for Asena")
-	flag.StringVar(&opts.SSLTLSPublicKey, "cert-file", "", "Path to SSL/TLS certificate file")
-	flag.StringVar(&opts.SSLTLSPrivateKey, "key-file", "", "Path to SSL/TLS private key file")
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&opts.PortHTTP, "http-port", "", "HTTP port for Asena")
+	fs.StringVar(&opts.PortHTTPS, "https-port", "", "HTTPS port for Asena")
+	fs.StringVar(&opts.SSLTLSPublicKey, "cert-file", "", "Path to SSL/TLS certificate file")
+	fs.StringVar(&opts.SSLTLSPrivateKey, "key-file", "", "Path to SSL/TLS private key file")
 
-	flag.Usage = func() {
+	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\nUsage:\n    asena [flags]\n\nFlags:\n")
-		flag.PrintDefaults()
+		fs.PrintDefaults()
 	}
 
-	if err := flag.CommandLine.Parse(os.Args[1:]); err != nil {
+	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "Error:\t%v\n\n", err)
-		flag.Usage()
+		fs.Usage()
 		os.Exit(2)
 	}
 

--- a/pkg/cli/parser_test.go
+++ b/pkg/cli/parser_test.go
@@ -1,25 +1,18 @@
 package cli
 
 import (
-	"flag"
 	"os"
 	"testing"
 )
 
-func resetFlags() {
-	// Reset the default CommandLine flag set for each test
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-}
-
 func TestParse_AllFlagsProvided(t *testing.T) {
-	resetFlags()
 	os.Args = []string{
 		"asena",
 		"--http-port=:8080",
 		"--https-port=:8443",
 		"--cert-file=/path/cert.pem",
 		"--key-file=/path/key.pem",
-	}
+	} 
 
 	opts := Parse()
 
@@ -38,7 +31,7 @@ func TestParse_AllFlagsProvided(t *testing.T) {
 }
 
 func TestParse_NoFlagsProvided(t *testing.T) {
-	resetFlags()
+
 	os.Args = []string{"asena"}
 
 	opts := Parse()


### PR DESCRIPTION
Fixes a panic caused by loading the Asena configuration more than once in the same process.

Previously, `cli.Parse()` was called from `config.setAsenaConfigs()`. Since it registered flags on Go's global `flag.CommandLine`, each call to `NewAsenaConfigService()` attempted to register the same flags again, resulting in a `flag redefined` panic.

Changes:

- Parse CLI flags once during application startup in `cmd/startasena.go`.
- Pass parsed CLI options through `NewAsenaConfigService()` to `setAsenaConfigs()`.
- Replace the global flag set in `cli.Parse()` with a dedicated `flag.FlagSet`.
- Update CLI and configuration tests to match the new API.

This removes the flag re-registration issue and makes the CLI parser safe to use across multiple initializations and tests.

Closes #59 